### PR TITLE
re-add removed return statement

### DIFF
--- a/lua/project_nvim/api.lua
+++ b/lua/project_nvim/api.lua
@@ -363,6 +363,8 @@ function Api.set_pwd(dir, method)
             vim.notify(msg, WARN)
         end
     end
+
+    return true
 end
 
 ---@param path? 'datapath'|'projectpath'|'historyfile'


### PR DESCRIPTION
# Re-add Removed `return` Statement

I'm not getting list of files upon selecting a project.
I believe refactor PR remove return statement so adding those back. 
https://github.com/DrKJeff16/project.nvim/commit/004fe69696cacfef155d65de87ad0b605e13cc76#diff-aeaaabe8d233692229dfb54a5bd8ad277008a9887bb08f57596978fa0bf42ccaL358

p.s.
thanks for maintaining the fork