### PR TITLE
handle fdfind for debian hosts

### DIFF
--- a/lua/project/health.lua
+++ b/lua/project/health.lua
@@ -44,8 +44,10 @@ function Health.setup_check()
 
     if vim.fn.executable('fd') == 1 then
         h_ok('`fd` executable in `PATH`')
+    elseif vim.fn.executable('fdfind') == 1 then
+        h_ok('`fdfind` executable in `PATH`')
     else
-        h_warn('`fd` executable not found! Some utilities from this plugin may not work.')
+        h_warn('`fd` nor `fdfind` were found! Some utilities from this plugin may not work.')
     end
 
     if is_windows() and vim.g.project_disable_win32_warning ~= 1 then

--- a/lua/project/popup.lua
+++ b/lua/project/popup.lua
@@ -43,11 +43,20 @@ local function hidden_avail(path, hidden)
             hidden = { hidden, 'boolean' },
         })
     end
-    if vim.fn.executable('fd') ~= 1 then
-        error(('(%s.hidden_avail): `fd` not found in your PATH!'):format(MODSTR), ERROR)
+
+    local fd = ''
+    if vim.fn.executable('fd') == 1 then
+        fd = 'fd'
+    elseif vim.fn.executable('fdfind') == 1 then -- Debian Users
+        fd = 'fdfind'
+    else
+        error(
+            ('(%s.hidden_avail): `fd` nor `fdfind` not found in your PATH!'):format(MODSTR),
+            ERROR
+        )
     end
 
-    local cmd = { 'fd', '-Iad1' }
+    local cmd = { fd, '-Iad1' }
     if hidden then
         table.insert(cmd, '-H')
     end


### PR DESCRIPTION
Came across this warning in healthcheck
> - ⚠️ WARNING `fd` executable not found! Some utilities from this plugin may not work.

`fd` is called `fdfind` in Debian (https://github.com/sharkdp/fd?tab=readme-ov-file#on-debian)

> Note that the binary is called fdfind as the binary name fd is already used by another package.

Although it recommands to create a link to `fd`, we can also have the plugin detect and use `fdfind` which is what [Telescope does](https://github.com/nvim-telescope/telescope.nvim/blob/b4da76be54691e854d3e0e02c36b0245f945c2c7/lua/telescope/builtin/__files.lua#L278) (and shamlessly copied)
```
    elseif 1 == vim.fn.executable "fd" then
      return { "fd", "--type", "f", "--color", "never" }
    elseif 1 == vim.fn.executable "fdfind" then
      return { "fdfind", "--type", "f", "--color", "never" }
```

After the change
> - ✅ OK `fd` executable in `PATH`