### PR TITLE
fix(api): normalize path for windows in Api.on_buf_enter

### DIFF
--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -351,6 +351,7 @@ function Api.on_buf_enter(verbose, bufnr)
     end
 
     local dir = vim.fn.fnamemodify(vim.api.nvim_buf_get_name(bufnr), ':p:h')
+    dir = Util.is_windows() and dir:gsub('\\', '/') or dir
     if not (Path.exists(dir) and Path.root_included(dir)) or Path.is_excluded(dir) then
         return
     end


### PR DESCRIPTION
On Windows, due to a different path seperator, `Api.on_buf_enter` or `:ProjectRoot` currently doesn't work.
This fix simply normalizes the path for this function, with the same logic already used in `Api.find_pattern_root`.
