### PR TITLE
fix: remove buflisted guard

### DIFF
--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -63,8 +63,7 @@ end
 function Api.buffer_valid(bufnr)
   Util.validate({ bufnr = { bufnr, { 'number' } } })
 
-  return vim.api.nvim_buf_is_valid(bufnr)
-    and vim.api.nvim_buf_is_loaded(bufnr)
+  return vim.api.nvim_buf_is_valid(bufnr) and vim.api.nvim_buf_is_loaded(bufnr)
 end
 
 ---@return string|nil last


### PR DESCRIPTION
commit [5eaa011](https://github.com/DrKJeff16/project.nvim/commit/5eaa01123257659c026612973c1ab2fdedddeea7) broke my current setup. I've been using `require('project').get_project_root()` during vim startup to detect the project root. Before this change, the `pattern` detecttion method managed to match on the `.git` directory on the cwd and correctly identified the project root. After the change, it stopped detecting the root due to the fact that the current buffer is `1` and it doesn't have `buflisted` by default, so none of the detection methods are run.

My setup is [here](https://github.com/perrin4869/dotfiles/blob/master/home/.config/nvim/plugin/project.lua)