### PR TITLE
feat(snacks): keep default prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,7 @@ By default, `setup()` loads with the following options:
     opts = {
       hidden = false,
       sort = 'newest',
-      title = 'Select Project: ',
+      title = 'Select Project',
       layout = 'select',
       -- icon = {},
       -- path_icons = {},
@@ -576,7 +576,7 @@ require('project').setup({
     opts = {
       sort = 'newest',
       hidden = false,
-      title = 'Select Project: ',
+      title = 'Select Project',
       layout = 'select',
       -- icon = {},
       -- path_icons = {},

--- a/lua/project/extensions/snacks.lua
+++ b/lua/project/extensions/snacks.lua
@@ -13,7 +13,7 @@ local M = {}
 ---@field path_icons? { match: string, icon: string, highlight: string }[]
 ---@field sort? 'newest'|'oldest'
 M.config = {
-  title = 'Select Project: ',
+  title = 'Select Project',
   layout = 'select',
   icon = { icon = ' ', highlight = 'Directory' },
   path_icons = {},


### PR DESCRIPTION
<!--
PLEASE MAKE SURE YOU READ THE `CONTRIBUTING.md` FILE.
-->

<!--
## Related Issues

- #1
- #2
--->

## Checks

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested my changes (if applicable)

## Description

I'd like to keep the default snacks picker prompt
<img width="765" height="69" alt="Files" src="https://github.com/user-attachments/assets/9ecb2462-5690-4db7-babc-25b2bdbb0619" />

Before
<img width="995" height="69" alt="before" src="https://github.com/user-attachments/assets/b4dce99b-8c12-4700-9e00-738bd7ee0ce8" />

After
<img width="996" height="68" alt="after" src="https://github.com/user-attachments/assets/dca85be9-f9d3-432d-af9b-4fd7e45e3e65" />


## Changes

Changed `prompt` settings to `title` and keeps default snacks prompt (does this counts as breaking change? should we keep the old settings name?)

<!--
- Changed x
- Changed y
- Renamed z
...
-->

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
