### PR TITLE
refactor!: allow projects to be named

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,10 +441,12 @@ lualine_b = {
     "project",
 
     -- Can be:
-    -- - `'short'`         - Only shows the basename of the project root directory (default)
+    -- - `'short'`         - Only shows the basename of the project root directory
     -- - `'full'`          - Shows the full path but without expanding the home directory
     -- - `'full_expanded'` - Shows the full, expanded path
-    format = 'short',
+    -- - `'name'`          - (default) Will show the current project's name. ONLY WORKS IF HISTORY
+    --                       HAS BEEN MIGRATED, OTHERWISE `'short'` WILL BE USED
+    format = 'name',
 
     -- Text to display when no project root is found (set to `nil` or empty string to disable)
     no_project = 'N/A',

--- a/lua/lualine/components/project.lua
+++ b/lua/lualine/components/project.lua
@@ -44,13 +44,13 @@ local M = require('lualine.component'):extend()
 
 ---@class Project.LuaLineOpts
 ---@field separator? string
----@field format? 'short'|'full'|'full_expanded'
+---@field format? 'short'|'full'|'full_expanded'|'name'
 ---@field no_project? string
 ---@field enclose_pair? { [1]: string|nil, [2]: string|nil }|nil
 local defaults = {
   separator = ' ',
   no_project = 'N/A',
-  format = 'short',
+  format = 'name',
   enclose_pair = nil,
 }
 
@@ -89,16 +89,17 @@ function M:project_root()
   local bufnr = vim.api.nvim_get_current_buf()
   local ft = Util.optget('filetype', 'buf', bufnr)
   local bt = Util.optget('buftype', 'buf', bufnr)
-  local msg = ''
+  local msg = '' ---@type string
   if in_list(Config.options.disable_on.ft, ft) or in_list(Config.options.disable_on.bt, bt) then
     return msg
   end
 
+  local History = require('project.util.history')
   local format = self.options.format or 'short'
   local curr = require('project.api').get_current_project(bufnr)
   local root = require('project.api').get_project_root(bufnr)
   if
-    not in_list({ 'short', 'full', 'full_expanded' }, format)
+    not in_list({ 'short', 'full', 'full_expanded', 'name' }, format)
     or not (curr and root)
     or curr ~= root
   then
@@ -107,7 +108,10 @@ function M:project_root()
     msg = Util.rstrip('/', vim.fn.fnamemodify(curr, ':p'))
   elseif format == 'full' then
     msg = vim.fn.fnamemodify(Util.rstrip('/', vim.fn.fnamemodify(curr, ':p')), ':~')
-  elseif format == 'short' then
+  elseif format == 'name' and not History.legacy then
+    msg = History.find_entry('recent', curr, 'name')
+  end
+  if format == 'short' or not msg then
     msg = vim.fn.fnamemodify(Util.rstrip('/', vim.fn.fnamemodify(curr, ':p')), ':p:h:t')
   end
 

--- a/lua/picker/sources/projects.lua
+++ b/lua/picker/sources/projects.lua
@@ -44,7 +44,7 @@ local M = {}
 
 ---@return ProjectPickerItem[] items
 function M.get()
-  local recents = require('project').get_recent_projects()
+  local recents = require('project').get_recent_projects(true)
   if Config.options.picker.sort == 'newest' then
     recents = Util.reverse(recents)
   end

--- a/lua/picker/sources/projects.lua
+++ b/lua/picker/sources/projects.lua
@@ -1,3 +1,5 @@
+---@module 'picker'
+
 local Util = require('project.util')
 local Config = require('project.config')
 

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -90,7 +90,7 @@ function Api.check_oil(bufnr)
 
   ---SOURCE: https://github.com/cosmicbuffalo/root_swapper.nvim/blob/main/lua/root_swapper.lua
   dir = (ok and oil and oil.get_current_dir) and oil.get_current_dir(bufnr)
-    or bufname:gsub('^oil://', '')
+      or bufname:gsub('^oil://', '')
 
   if dir then
     dir = Util.rstrip('/', dir)
@@ -98,7 +98,7 @@ function Api.check_oil(bufnr)
   return dir
 end
 
----@return string|nil last
+---@return string|ProjectHistoryEntry|nil last
 ---@nodiscard
 function Api.get_last_project()
   local recent = History.get_recent_projects()
@@ -157,8 +157,8 @@ function Api.find_lsp_root(bufnr)
     )
     if valid then
       if
-        Config.options.lsp.use_pattern_matching
-        and Path.root_included(client.config.root_dir) == nil
+          Config.options.lsp.use_pattern_matching
+          and Path.root_included(client.config.root_dir) == nil
       then
         return
       end
@@ -245,7 +245,14 @@ function Api.set_pwd(dir, method)
 
   local modified = false
   local unexpand_dir = Util.rstrip('/', vim.fn.fnamemodify(dir, ':p:~'))
-  if not (History.session_projects and vim.list_contains(History.session_projects, dir)) then
+  if not History.session_projects then
+    History.session_projects = {}
+  end
+  if
+      vim.tbl_contains(History.session_projects, function(val)
+        return vim.deep_equal(val, dir)
+      end, { predicate = true })
+  then
     table.insert(History.session_projects, dir)
     modified = true
     Log.debug(('Added project %s to the top of session list'):format(unexpand_dir))
@@ -253,14 +260,19 @@ function Api.set_pwd(dir, method)
   if not modified and #History.session_projects > 1 then
     local old_pos ---@type integer
     for k, v in ipairs(History.session_projects) do
-      if v == dir then
+      local v_dir = History.legacy and v or v.path
+      if v_dir == dir then
         old_pos = k
         break
       end
     end
     if old_pos ~= 1 then
       table.remove(History.session_projects, old_pos)
-      table.insert(History.session_projects, 1, dir) -- HACK: Move project to start of table
+      table.insert(
+        History.session_projects,
+        1,
+        History.legacy and dir or { path = dir, name = vim.fn.fnamemodify(dir, ':p:h:t') }
+      )
       Log.debug(
         ('Moved project %s from %d to the top of session list'):format(unexpand_dir, old_pos)
       )

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -98,16 +98,31 @@ function Api.check_oil(bufnr)
   return dir
 end
 
----@return string|ProjectHistoryEntry|nil last
+---@overload fun(): last: string|nil
+---@overload fun(entry: false): last: string|nil
+---@overload fun(entry: true): last: ProjectHistoryEntry|nil
 ---@nodiscard
-function Api.get_last_project()
+function Api.get_last_project(entry)
+  Util.validate({ entry = { entry, { 'boolean', 'nil' }, true } })
+  if entry == nil then
+    entry = false
+  end
+
   local recent = History.get_recent_projects()
   if vim.tbl_isempty(recent) or #recent == 1 then
     return
   end
 
   recent = Util.reverse(recent)
-  return #History.session_projects <= 1 and recent[2] or recent[1]
+
+  local res = #History.session_projects <= 1 and recent[2] or recent[1]
+  if Util.is_type('string', res) then
+    ---@cast res string
+    return res
+  end
+
+  ---@cast res ProjectHistoryEntry
+  return entry and res or res.path
 end
 
 ---@param path? ProjectPaths

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -90,7 +90,7 @@ function Api.check_oil(bufnr)
 
   ---SOURCE: https://github.com/cosmicbuffalo/root_swapper.nvim/blob/main/lua/root_swapper.lua
   dir = (ok and oil and oil.get_current_dir) and oil.get_current_dir(bufnr)
-      or bufname:gsub('^oil://', '')
+    or bufname:gsub('^oil://', '')
 
   if dir then
     dir = Util.rstrip('/', dir)
@@ -172,8 +172,8 @@ function Api.find_lsp_root(bufnr)
     )
     if valid then
       if
-          Config.options.lsp.use_pattern_matching
-          and Path.root_included(client.config.root_dir) == nil
+        Config.options.lsp.use_pattern_matching
+        and Path.root_included(client.config.root_dir) == nil
       then
         return
       end
@@ -264,9 +264,9 @@ function Api.set_pwd(dir, method)
     History.session_projects = {}
   end
   if
-      vim.tbl_contains(History.session_projects, function(val)
-        return vim.deep_equal(val, dir)
-      end, { predicate = true })
+    vim.tbl_contains(History.session_projects, function(val)
+      return vim.deep_equal(val, dir)
+    end, { predicate = true })
   then
     table.insert(History.session_projects, dir)
     modified = true

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -265,7 +265,7 @@ function Api.set_pwd(dir, method)
   end
   if
     not vim.tbl_contains(History.session_projects, function(val)
-      return vim.deep_equal(val, dir)
+      return vim.deep_equal(History.legacy and val or val.path, dir)
     end, { predicate = true })
   then
     table.insert(History.session_projects, History.legacy and dir or {
@@ -276,11 +276,15 @@ function Api.set_pwd(dir, method)
     Log.debug(('Added project %s to the top of session list'):format(unexpand_dir))
   end
   if not modified and #History.session_projects > 1 then
+    local name = ''
     local old_pos = nil ---@type integer|nil
     for k, v in ipairs(History.session_projects) do
       local v_dir = History.legacy and v or v.path
       if v_dir == dir then
         old_pos = k --[[@as integer]]
+        if not History.legacy then
+          name = v.name
+        end
         break
       end
     end
@@ -289,7 +293,7 @@ function Api.set_pwd(dir, method)
       table.insert(
         History.session_projects,
         1,
-        History.legacy and dir or { path = dir, name = vim.fn.fnamemodify(dir, ':p:h:t') }
+        History.legacy and dir or { path = dir, name = name }
       )
       Log.debug(
         ('Moved project %s from %d to the top of session list'):format(unexpand_dir, old_pos)

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -270,7 +270,8 @@ function Api.set_pwd(dir, method)
   then
     table.insert(History.session_projects, History.legacy and dir or {
       path = dir,
-      name = vim.fn.fnamemodify(dir, ':p:h:h:t') .. '/' .. vim.fn.fnamemodify(dir, ':p:h:t'),
+      name = History.find_entry('recent', dir, 'name')
+        or vim.fn.fnamemodify(dir, ':p:h:h:t') .. '/' .. vim.fn.fnamemodify(dir, ':p:h:t'),
     })
     modified = true
     Log.debug(('Added project %s to the top of session list'):format(unexpand_dir))
@@ -430,6 +431,21 @@ function Api.get_current_project(bufnr)
   local curr, method = Api.get_project_root(bufnr)
   local last = Api.get_last_project()
   return curr, method, last
+end
+
+---@param bufnr? integer
+---@return string|nil name
+---@nodiscard
+function Api.get_current_project_name(bufnr)
+  Util.validate({ bufnr = { bufnr, { 'number', 'nil' }, true } })
+  bufnr = (bufnr and Util.is_int(bufnr, bufnr >= 0)) and bufnr or vim.api.nvim_get_current_buf()
+
+  if not Api.buffer_valid(bufnr) then
+    return
+  end
+
+  local curr = Api.get_project_root(bufnr)
+  return History.find_entry('recent', curr, 'name')
 end
 
 ---@param bufnr? integer

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -264,11 +264,14 @@ function Api.set_pwd(dir, method)
     History.session_projects = {}
   end
   if
-    vim.tbl_contains(History.session_projects, function(val)
+    not vim.tbl_contains(History.session_projects, function(val)
       return vim.deep_equal(val, dir)
     end, { predicate = true })
   then
-    table.insert(History.session_projects, dir)
+    table.insert(History.session_projects, History.legacy and dir or {
+      path = dir,
+      name = vim.fn.fnamemodify(dir, ':p:h:h:t') .. '/' .. vim.fn.fnamemodify(dir, ':p:h:t'),
+    })
     modified = true
     Log.debug(('Added project %s to the top of session list'):format(unexpand_dir))
   end

--- a/lua/project/api.lua
+++ b/lua/project/api.lua
@@ -276,15 +276,15 @@ function Api.set_pwd(dir, method)
     Log.debug(('Added project %s to the top of session list'):format(unexpand_dir))
   end
   if not modified and #History.session_projects > 1 then
-    local old_pos ---@type integer
+    local old_pos = nil ---@type integer|nil
     for k, v in ipairs(History.session_projects) do
       local v_dir = History.legacy and v or v.path
       if v_dir == dir then
-        old_pos = k
+        old_pos = k --[[@as integer]]
         break
       end
     end
-    if old_pos ~= 1 then
+    if old_pos and old_pos ~= 1 then
       table.remove(History.session_projects, old_pos)
       table.insert(
         History.session_projects,

--- a/lua/project/commands.lua
+++ b/lua/project/commands.lua
@@ -273,7 +273,7 @@ function Commands.create_user_commands()
           if
             not (
               ctx.bang
-              or vim.tbl_contains(recent, function(val)
+              or not vim.tbl_contains(recent, function(val)
                 return vim.deep_equal(val, path)
               end, { predicate = true })
               or path ~= ''

--- a/lua/project/commands.lua
+++ b/lua/project/commands.lua
@@ -73,22 +73,10 @@ local function complete_items(_, line)
   end
 
   local recents = Util.reverse(History.get_recent_projects(true, true))
-  local recent_paths = History.legacy and recents or {} ---@type string[]
-  if not History.legacy then
-    ---@cast recents ProjectHistoryEntry[]
-    for _, v in ipairs(recents) do
-      table.insert(recent_paths, v.path)
-    end
-  end
-  if args[#args] == '' then
-    return recent_paths
-  end
-
   local res = {} ---@type string[]
   for _, proj in ipairs(recents) do
-    local project = History.legacy and proj or proj.path ---@type string
-    if vim.startswith(project, args[#args]) then
-      table.insert(res, project)
+    if vim.startswith(proj, args[#args]) then
+      table.insert(res, proj)
     end
   end
   return res
@@ -261,7 +249,7 @@ function Commands.create_user_commands()
           return
         end
 
-        local recent = History.get_recent_projects()
+        local recent = History.get_recent_projects(true)
         if not recent then
           Log.error('(:ProjectDelete): No recent projects!')
           vim.notify('(:ProjectDelete): No recent projects!', ERROR)
@@ -363,7 +351,7 @@ function Commands.create_user_commands()
       name = 'ProjectHistory',
       desc = 'Manage project history',
       bang = true,
-      nargs = '*',
+      nargs = '?',
       complete = function(_, line)
         local args = vim.split(line, '%s+', { trimempty = false })
         if (args[1]:sub(-1) == '!' and #args == 1) or #args > 2 then
@@ -371,7 +359,7 @@ function Commands.create_user_commands()
         end
 
         local res = {}
-        for _, choice in ipairs({ 'clear' }) do
+        for _, choice in ipairs({ 'clear', 'migrate' }) do
           if vim.startswith(choice, args[2]) then
             table.insert(res, choice)
           end
@@ -379,16 +367,22 @@ function Commands.create_user_commands()
         return res
       end,
       callback = function(ctx)
-        if vim.tbl_isempty(ctx.fargs) then
+        ctx.fargs[1] = ctx.fargs[1] or ''
+        if ctx.fargs[1] == '' then
           History.toggle_win()
           return
         end
 
-        if ctx.fargs[1] ~= 'clear' or #ctx.fargs > 1 then
+        if not vim.list_contains({ 'clear', 'migrate' }, ctx.fargs[1]) or #ctx.fargs > 1 then
           vim.notify('Usage:  `:ProjectHistory[!] [clear]`', WARN)
           return
         end
-        History.clear_historyfile(ctx.bang)
+
+        if ctx.fargs[1] == 'clear' then
+          History.clear_historyfile(ctx.bang)
+        end
+
+        History.migrate()
       end,
     },
     {

--- a/lua/project/commands.lua
+++ b/lua/project/commands.lua
@@ -64,10 +64,41 @@ local Api = require('project.api')
 local Log = require('project.util.log')
 local Config = require('project.config')
 
+---@param line string
+---@return string[] items
+local function complete_items(_, line)
+  local args = vim.split(line, '%s+', { trimempty = false })
+  if args[1]:sub(-1) == '!' and #args == 1 then
+    return {}
+  end
+
+  local recents = Util.reverse(History.get_recent_projects(true, true))
+  local recent_paths = History.legacy and recents or {} ---@type string[]
+  if not History.legacy then
+    ---@cast recents ProjectHistoryEntry[]
+    for _, v in ipairs(recents) do
+      table.insert(recent_paths, v.path)
+    end
+  end
+  if args[#args] == '' then
+    return recent_paths
+  end
+
+  local res = {} ---@type string[]
+  for _, proj in ipairs(recents) do
+    local project = History.legacy and proj or proj.path ---@type string
+    if vim.startswith(project, args[#args]) then
+      table.insert(res, project)
+    end
+  end
+  return res
+end
+
 ---@class Project.Commands
+---@field cmds table<string, Project.CMD>
 local Commands = {}
 
-Commands.cmds = {} ---@type table<string, Project.CMD>
+Commands.cmds = {}
 
 ---@param specs Project.Commands.Spec[]
 function Commands.new(specs)
@@ -223,33 +254,7 @@ function Commands.create_user_commands()
       desc = 'Deletes the projects given as args, assuming they are valid. No args open a popup',
       bang = true,
       nargs = '*',
-      complete = function(_, line)
-        local args = vim.split(line, '%s+', { trimempty = false })
-        if args[1]:sub(-1) == '!' and #args == 1 then
-          return {}
-        end
-
-        local recents = Util.reverse(History.get_recent_projects(true))
-        local recent_paths = History.legacy and recents or {} ---@type string[]
-        if not History.legacy then
-          ---@cast recents ProjectHistoryEntry[]
-          for _, v in ipairs(recents) do
-            table.insert(recent_paths, v.path)
-          end
-        end
-        if args[#args] == '' then
-          return recent_paths
-        end
-
-        local res = {} ---@type string[]
-        for _, proj in ipairs(recents) do
-          local project = History.legacy and proj or proj.path ---@type string
-          if vim.startswith(project, args[#args]) then
-            table.insert(res, project)
-          end
-        end
-        return res
-      end,
+      complete = complete_items,
       callback = function(ctx)
         if not ctx or vim.tbl_isempty(ctx.fargs) then
           Popup.delete_menu()
@@ -411,6 +416,24 @@ function Commands.create_user_commands()
       desc = 'Opens a menu to select a project from your history',
       callback = function()
         Popup.recents_menu()
+      end,
+    },
+    {
+      name = 'ProjectRename',
+      desc = 'Rename a project from your history',
+      nargs = '?',
+      complete = complete_items,
+      callback = function(ctx)
+        if History.legacy then
+          return
+        end
+
+        ctx.fargs[1] = ctx.fargs[1] or ''
+        if ctx.fargs[1] == '' then
+          Popup.rename_menu()
+          return
+        end
+        Popup.rename_input(Util.rstrip('/', vim.fn.fnamemodify(ctx.fargs[1], ':p')))
       end,
     },
     {

--- a/lua/project/commands.lua
+++ b/lua/project/commands.lua
@@ -187,10 +187,10 @@ function Commands.create_user_commands()
           input = Util.rstrip('/', (vim.fn.fnamemodify(input, ':p')))
           if Util.dir_exists(input) then
             if
-                Api.current_project ~= input
-                and not vim.tbl_contains(session, function(val)
-                  return vim.deep_equal(val, input)
-                end, { predicate = true })
+              Api.current_project ~= input
+              and not vim.tbl_contains(session, function(val)
+                return vim.deep_equal(val, input)
+              end, { predicate = true })
             then
               Api.set_pwd(input, 'command')
               History.write_history()
@@ -271,13 +271,13 @@ function Commands.create_user_commands()
             path = path:sub(1, path:len() - 1)
           end
           if
-              not (
-                ctx.bang
-                or vim.tbl_contains(recent, function(val)
-                  return vim.deep_equal(val, path)
-                end, { predicate = true })
-                or path ~= ''
-              )
+            not (
+              ctx.bang
+              or vim.tbl_contains(recent, function(val)
+                return vim.deep_equal(val, path)
+              end, { predicate = true })
+              or path ~= ''
+            )
           then
             msg = ('(:ProjectDelete): Could not delete `%s`, aborting'):format(path)
             Log.error(msg)
@@ -285,9 +285,9 @@ function Commands.create_user_commands()
             return
           end
           if
-              vim.tbl_contains(recent, function(val)
-                return vim.deep_equal(val, path)
-              end, { predicate = true })
+            vim.tbl_contains(recent, function(val)
+              return vim.deep_equal(val, path)
+            end, { predicate = true })
           then
             History.delete_project(path)
           end

--- a/lua/project/commands.lua
+++ b/lua/project/commands.lua
@@ -42,15 +42,14 @@ local complete_types = { ---@diagnostic disable-line:unused-local
   var = 1,
 }
 
----@alias ProjectCmdFun fun(ctx?: vim.api.keyset.create_user_command.command_args)
 ---@alias CompletorFunc fun(lead: string, line: string, pos: integer): completions: string[]
 ---@alias Project.CMD
 ---|{ desc: string, name: string, bang: boolean, complete?: (CompletorFunc)|CompleteTypes, nargs?: string|integer }
----|ProjectCmdFun
+---|fun(ctx?: vim.api.keyset.create_user_command.command_args)
 
 ---@class Project.Commands.Spec
 ---@field bang boolean|nil
----@field callback ProjectCmdFun
+---@field callback fun(ctx?: vim.api.keyset.create_user_command.command_args)
 ---@field complete nil|CompleteTypes|CompletorFunc
 ---@field desc string
 ---@field name string
@@ -187,7 +186,12 @@ function Commands.create_user_commands()
         for _, input in ipairs(ctx.fargs) do
           input = Util.rstrip('/', (vim.fn.fnamemodify(input, ':p')))
           if Util.dir_exists(input) then
-            if Api.current_project ~= input and not vim.list_contains(session, input) then
+            if
+                Api.current_project ~= input
+                and not vim.tbl_contains(session, function(val)
+                  return vim.deep_equal(val, input)
+                end, { predicate = true })
+            then
               Api.set_pwd(input, 'command')
               History.write_history()
             else
@@ -226,14 +230,22 @@ function Commands.create_user_commands()
         end
 
         local recents = Util.reverse(History.get_recent_projects(true))
+        local recent_paths = History.legacy and recents or {} ---@type string[]
+        if not History.legacy then
+          ---@cast recents ProjectHistoryEntry[]
+          for _, v in ipairs(recents) do
+            table.insert(recent_paths, v.path)
+          end
+        end
         if args[#args] == '' then
-          return recents
+          return recent_paths
         end
 
         local res = {} ---@type string[]
         for _, proj in ipairs(recents) do
-          if vim.startswith(proj, args[#args]) then
-            table.insert(res, proj)
+          local project = History.legacy and proj or proj.path ---@type string
+          if vim.startswith(project, args[#args]) then
+            table.insert(res, project)
           end
         end
         return res
@@ -258,13 +270,25 @@ function Commands.create_user_commands()
           if path:sub(-1) == '/' then
             path = path:sub(1, path:len() - 1)
           end
-          if not (ctx.bang or vim.list_contains(recent, path) or path ~= '') then
+          if
+              not (
+                ctx.bang
+                or vim.tbl_contains(recent, function(val)
+                  return vim.deep_equal(val, path)
+                end, { predicate = true })
+                or path ~= ''
+              )
+          then
             msg = ('(:ProjectDelete): Could not delete `%s`, aborting'):format(path)
             Log.error(msg)
             vim.notify(msg, ERROR)
             return
           end
-          if vim.list_contains(recent, path) then
+          if
+              vim.tbl_contains(recent, function(val)
+                return vim.deep_equal(val, path)
+              end, { predicate = true })
+          then
             History.delete_project(path)
           end
         end

--- a/lua/project/config.lua
+++ b/lua/project/config.lua
@@ -42,7 +42,11 @@ function Config.setup(options)
   ---CREDITS: https://github.com/ahmedkhalf/project.nvim/pull/111
   vim.o.autochdir = Config.options.enable_autochdir
 
-  require('project.util.path').init(Config.options.datapath) -- WARN: THIS GOES FIRST!!!!
+  -- WARN: THIS GOES FIRST!!!!
+  require('project.util.path').init(
+    Config.options.history.save_dir,
+    Config.options.history.save_file
+  )
 
   local Log = require('project.util.log')
   if Config.options.log.enabled then
@@ -89,7 +93,7 @@ function Config.get_config()
     'verify',
     'verify_datapath',
     'verify_fzf_lua',
-    'verify_histsize',
+    'verify_history',
     'verify_lists',
     'verify_logging',
     'verify_lsp',

--- a/lua/project/config/defaults.lua
+++ b/lua/project/config/defaults.lua
@@ -9,6 +9,12 @@ local action_names = { ---@diagnostic disable-line:unused-local
   search_in_project_files = 1,
 }
 
+---@enum (key) ProjectOpts.Show
+local show = { ---@diagnostic disable-line:unused-local
+  names = 1,
+  paths = 1,
+}
+
 ---@enum (key) ProjectOpts.ScopeChdir
 local scope_chdir = { ---@diagnostic disable-line:unused-local
   global = 1,
@@ -65,6 +71,40 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---@field allow boolean
 ---@field notify boolean
 
+---Table of options used for history management.
+--- ---
+---@class ProjectOpts.History
+---The directory in which `project.nvim` will store the project history.
+---
+---For more info, run `:lua vim.print(require('project').get_history_paths())`
+--- ---
+---Default: `vim.fn.stdpath('data')`
+--- ---
+---@field save_dir? string
+---The history file name for `project.nvim`..
+---
+---If it doesn't end with `.json`, the file extension will be appended.
+---
+---If the string containes invalid chars (e.g. `/`, `\\`, `!`, `?`, etc.) an error will be raised,
+--- ---
+---Default: `'project_history.json'`
+--- ---
+---@field save_file? string
+---The history file size. (by `@acristoffers`)
+---
+---This will indicate how many entries will be written to the history file.
+---
+---Set to `0` for no limit.
+--- ---
+---Default: `100`
+--- ---
+---@field size? integer
+
+---@class ProjectDefaults.History: ProjectOpts.History
+---@field save_dir string
+---@field save_file string
+---@field size integer
+
 ---Table of options used for the snacks picker.
 --- ---
 ---@class ProjectOpts.Snacks
@@ -76,10 +116,12 @@ local sort = { ---@diagnostic disable-line:unused-local
 --- ---
 ---@field enabled? boolean
 ---@field opts? ProjectSnacksConfig
+---@field show? ProjectOpts.Show
 
 ---@class ProjectDefaults.Snacks: ProjectOpts.Snacks
 ---@field enabled boolean
 ---@field opts ProjectSnacksConfig
+---@field show ProjectOpts.Show
 
 ---Table of options used for the telescope picker.
 --- ---
@@ -108,6 +150,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---Default: `false`
 --- ---
 ---@field prefer_file_browser? boolean
+---@field show? ProjectOpts.Show
 ---Determines whether the newest projects come first in the
 ---telescope picker (`'newest'`), or the oldest (`'oldest'`).
 --- ---
@@ -119,6 +162,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---@field disable_file_picker boolean
 ---@field mappings Project.Telescope.DefaultMappings
 ---@field prefer_file_browser boolean
+---@field show ProjectOpts.Show
 ---@field sort ProjectOpts.Sort
 
 ---Options for logging utility.
@@ -163,6 +207,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---Default: `false`
 --- ---
 ---@field hidden? boolean
+---@field show? ProjectOpts.Show
 ---Determines whether the newest projects come first (`'newest'`),
 ---or the oldest (`'oldest'`).
 --- ---
@@ -173,6 +218,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---@class ProjectDefaults.Picker: ProjectOpts.Picker
 ---@field enabled boolean
 ---@field hidden boolean
+---@field show ProjectOpts.Show
 ---@field sort ProjectOpts.Sort
 
 ---Table of options used for `fzf-lua` integration
@@ -185,6 +231,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---Default: `false`
 --- ---
 ---@field enabled? boolean
+---@field show? ProjectOpts.Show
 ---Determines whether the newest projects come first (`'newest'`),
 ---or the oldest (`'oldest'`).
 --- ---
@@ -194,6 +241,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 
 ---@class ProjectDefaults.FzfLua: ProjectOpts.FzfLua
 ---@field enabled boolean
+---@field show ProjectOpts.Show
 ---@field sort ProjectOpts.Sort
 
 ---Table containing all the LSP-adjacent options.
@@ -258,14 +306,6 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---Default: `nil`
 --- ---
 ---@field before_attach? nil|fun(target_dir: string, method: string)
----The path where `project.nvim` will store the project history directory,
----containing the project history in it.
----
----For more info, run `:lua vim.print(require('project').get_history_paths())`
---- ---
----Default: `vim.fn.stdpath('data')`
---- ---
----@field datapath? string
 ---Table of options used for control for detecting projects not owned by the current user.
 --- ---
 ---@field different_owners? ProjectOpts.DifferentOwners
@@ -299,15 +339,7 @@ local sort = { ---@diagnostic disable-line:unused-local
 ---Table of options used for the `fzf-lua` integration
 --- ---
 ---@field fzf_lua? ProjectOpts.FzfLua
----The history size. (by `@acristoffers`)
----
----This will indicate how many entries will be
----written to the history file.
----Set to `0` for no limit.
---- ---
----Default: `100`
---- ---
----@field historysize? integer
+---@field history? ProjectOpts.History
 ---Options for logging utility.
 --- ---
 ---@field log? ProjectOpts.Logging
@@ -377,11 +409,11 @@ local sort = { ---@diagnostic disable-line:unused-local
 
 local MODSTR = 'project.config.defaults'
 local WARN = vim.log.levels.WARN
+local ERROR = vim.log.levels.ERROR
 local Util = require('project.util')
 
 ---@class ProjectDefaults: ProjectOpts
 ---@field before_attach nil|fun(target_dir: string, method: string)
----@field datapath string
 ---@field different_owners ProjectDefaults.DifferentOwners
 ---@field disable_on ProjectDefaults.DisableOn
 ---@field enable_autochdir boolean
@@ -389,7 +421,7 @@ local Util = require('project.util')
 ---@field expand_excluded fun(self: ProjectDefaults)
 ---@field fzf_lua ProjectDefaults.FzfLua
 ---@field gen_methods fun(self: ProjectDefaults): methods: { [1]: 'pattern' }|{ [1]: 'lsp', [2]: 'pattern' }
----@field historysize integer
+---@field history ProjectDefaults.History
 ---@field log ProjectDefaults.Logging
 ---@field lsp ProjectDefaults.LSP
 ---@field manual_mode boolean
@@ -405,7 +437,7 @@ local Util = require('project.util')
 ---@field verify fun(self: ProjectDefaults)
 ---@field verify_datapath fun(self: ProjectDefaults)
 ---@field verify_fzf_lua fun(self: ProjectDefaults)
----@field verify_histsize fun(self: ProjectDefaults)
+---@field verify_history fun(self: ProjectDefaults)
 ---@field verify_lists fun(self: ProjectDefaults)
 ---@field verify_logging fun(self: ProjectDefaults)
 ---@field verify_lsp fun(self: ProjectDefaults)
@@ -415,9 +447,10 @@ local Util = require('project.util')
 ---@diagnostic disable-next-line:missing-fields
 local DEFAULTS = { ---@type ProjectDefaults
   different_owners = { allow = false, notify = true },
-  picker = { enabled = false, sort = 'newest', hidden = false },
+  picker = { enabled = false, sort = 'newest', hidden = false, show = 'paths' },
   snacks = {
     enabled = false,
+    show = 'paths',
     opts = {
       sort = 'newest',
       hidden = false,
@@ -472,12 +505,12 @@ local DEFAULTS = { ---@type ProjectDefaults
     },
     bt = { 'help', 'nofile', 'nowrite', 'terminal' },
   },
-  datapath = vim.fn.stdpath('data'),
-  historysize = 100,
-  fzf_lua = { enabled = false, sort = 'newest' },
+  history = { save_dir = vim.fn.stdpath('data'), save_file = 'project_history.json', size = 100 },
+  fzf_lua = { enabled = false, sort = 'newest', show = 'paths' },
   log = { enabled = false, max_size = 1.1, logpath = vim.fn.stdpath('state') },
   telescope = {
     sort = 'newest',
+    show = 'paths',
     prefer_file_browser = false,
     disable_file_picker = false,
     mappings = {
@@ -506,18 +539,42 @@ local DEFAULTS = { ---@type ProjectDefaults
 ---If the option is not valid, a warning will be raised and
 ---the value will revert back to the default.
 --- ---
-function DEFAULTS:verify_histsize()
-  Util.validate({ historysize = { self.historysize, { 'number', 'nil' }, true } })
+function DEFAULTS:verify_history()
+  Util.validate({ history = { self.history, { 'table', 'nil' }, true } })
+  self.history = self.history or {}
 
-  if not self.historysize or type(self.historysize) ~= 'number' then
-    self.historysize = DEFAULTS.historysize
+  Util.validate({
+    ['history.save_dir'] = { self.history.save_dir, { 'string', 'nil' }, true },
+    ['history.save_file'] = { self.history.save_file, { 'string', 'nil' }, true },
+    ['history.size'] = { self.history.size, { 'number', 'nil' }, true },
+  })
+  self.history.save_dir =
+    Util.rstrip('/', vim.fn.fnamemodify(self.history.save_dir or DEFAULTS.history.save_dir, ':p'))
+
+  self.history.save_file = self.history.save_file or DEFAULTS.history.save_file
+  self.history.size = self.history.size or DEFAULTS.history.size
+  if not Util.is_int(self.history.size, self.history.size >= 0) then
+    self.history.size = DEFAULTS.history.size
   end
 
-  if self.historysize >= 0 or self.historysize == math.floor(self.historysize) then
-    return
+  if
+    not Util.only_has_chars(
+      self.history.save_file,
+      'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-_.',
+      { spaces = true }
+    )
+  then
+    error('(project.nvim): Invalid chars in `history.save_file` setup option!', ERROR)
   end
-  vim.notify('`historysize` option invalid. Reverting to default option.', WARN)
-  self.historysize = DEFAULTS.historysize
+
+  if self.historysize and Util.is_int(self.historysize, self.historysize >= 0) then
+    vim.notify(
+      ('`options.historysize` is deprecated, use `options.history.size`!'):format(MODSTR),
+      WARN
+    )
+    self.history.size = self.historysize
+    self.historysize = nil ---@diagnostic disable-line:inject-field
+  end
 end
 
 ---Checks the `scope_chdir` option.
@@ -540,9 +597,23 @@ function DEFAULTS:verify_scope_chdir()
 end
 
 function DEFAULTS:verify_datapath()
-  if not (self.datapath and require('project.util').dir_exists(self.datapath)) then
-    vim.notify(('Invalid datapath `%s`, reverting to default.'):format(self.datapath), WARN)
-    self.datapath = DEFAULTS.datapath
+  Util.validate({ history = { self.history, { 'table', 'nil' }, true } })
+  self.history = self.history or {}
+
+  Util.validate({ ['history.save_dir'] = { self.history.save_dir, { 'string', 'nil' }, true } })
+
+  if self.datapath and Util.is_type('string', self.datapath) then
+    vim.notify(
+      ('`options.datapath` is deprecated, use `options.history.save_dir`!'):format(MODSTR),
+      WARN
+    )
+    self.history.save_dir = self.datapath
+    self.datapath = nil ---@diagnostic disable-line:inject-field
+  end
+
+  if not (self.history.save_dir and require('project.util').dir_exists(self.history.save_dir)) then
+    vim.notify(('Invalid save_dir `%s`, reverting to default.'):format(self.history.save_dir), WARN)
+    self.history.save_dir = DEFAULTS.history.save_dir
   end
 end
 
@@ -723,13 +794,12 @@ function DEFAULTS:verify()
 
   Util.validate({
     before_attach = { self.before_attach, { 'function', 'nil' }, true },
-    datapath = { self.datapath, { 'string', 'nil' }, true },
     different_owners = { self.different_owners, { 'table', 'nil' }, true },
     disable_on = { self.disable_on, { 'table', 'nil' }, true },
     enable_autochdir = { self.enable_autochdir, { 'boolean', 'nil' }, true },
     exclude_dirs = { self.exclude_dirs, { 'table', 'nil' }, true },
     fzf_lua = { self.fzf_lua, { 'table', 'nil' }, true },
-    historysize = { self.historysize, { 'number', 'nil' }, true },
+    history = { self.history, { 'table', 'nil' }, true },
     log = { self.log, { 'table', 'nil' }, true },
     lsp = { self.lsp, { 'table', 'nil' }, true },
     manual_mode = { self.manual_mode, { 'boolean', 'nil' }, true },
@@ -743,9 +813,9 @@ function DEFAULTS:verify()
     telescope = { self.telescope, { 'table', 'nil' }, true },
   })
 
+  self:verify_history()
   self:verify_datapath()
   self:verify_lsp()
-  self:verify_histsize()
   self:verify_scope_chdir()
   self:verify_logging()
   self:verify_owners()

--- a/lua/project/extensions/fzf-lua.lua
+++ b/lua/project/extensions/fzf-lua.lua
@@ -35,7 +35,7 @@ end
 
 ---@param cb fun(entry?: string|number, cb?: function)
 function M.exec(cb)
-  local results = Util.reverse(require('project.util.history').get_recent_projects())
+  local results = Util.reverse(require('project.util.history').get_recent_projects(true))
   if Config.options.fzf_lua.sort == 'oldest' then
     results = Util.reverse(results)
   end

--- a/lua/project/extensions/snacks.lua
+++ b/lua/project/extensions/snacks.lua
@@ -24,7 +24,7 @@ M.config = {
 ---@return snacks.picker.finder.Item[] items
 function M.gen_items()
   local items = {} ---@type snacks.picker.finder.Item[]
-  local recents = require('project').get_recent_projects()
+  local recents = require('project').get_recent_projects(true)
   if M.config.sort and M.config.sort == 'newest' then
     recents = Util.reverse(recents)
   end

--- a/lua/project/health.lua
+++ b/lua/project/health.lua
@@ -141,7 +141,8 @@ function M.project_check()
     vim.health.warn('No active session projects!')
     return
   end
-  for k, v in ipairs(Util.dedup(projects)) do
+  History.is_legacy(projects)
+  for k, v in ipairs(Util.dedup(projects, History.legacy and nil or 'name')) do
     vim.health.info(('%s. `%s`'):format(k, v))
   end
 end

--- a/lua/project/health.lua
+++ b/lua/project/health.lua
@@ -143,7 +143,14 @@ function M.project_check()
   end
   History.is_legacy(projects)
   for k, v in ipairs(Util.dedup(projects, History.legacy and nil or 'name')) do
-    vim.health.info(('%s. `%s`'):format(k, v))
+    if History.legacy then
+      vim.health.info(('%s. `%s`'):format(k, v))
+    else
+      local index = tostring(k)
+      vim.health.info(
+        ('%d. `%s`\n   %spath: `%s`'):format(index, v.name, (' '):rep(index:len() - 1), v.path)
+      )
+    end
   end
 end
 
@@ -182,7 +189,7 @@ end
 
 function M.recent_proj_check()
   vim.health.start('Recent Projects')
-  local recents = History.get_recent_projects()
+  local recents = History.get_recent_projects(false)
   if vim.tbl_isempty(recents) then
     vim.health.warn([[No projects found in history!
 
@@ -194,9 +201,22 @@ If this keeps appearing, though, check your config
 and submit an issue if pertinent.]])
     return
   end
+
   recents = Util.reverse(recents)
   for i, project in ipairs(recents) do
-    vim.health.info(('%d. `%s`'):format(i, project))
+    if History.legacy then
+      vim.health.info(('%d. `%s`'):format(i, project))
+    else
+      local index = tostring(i)
+      vim.health.info(
+        ('%d. `%s`\n   %spath: `%s`'):format(
+          index,
+          project.name,
+          (' '):rep(index:len() - 1),
+          project.path
+        )
+      )
+    end
   end
 end
 

--- a/lua/project/health.lua
+++ b/lua/project/health.lua
@@ -74,7 +74,7 @@ function M.options_check()
     'verify',
     'verify_datapath',
     'verify_fzf_lua',
-    'verify_histsize',
+    'verify_history',
     'verify_lists',
     'verify_logging',
     'verify_lsp',

--- a/lua/project/popup.lua
+++ b/lua/project/popup.lua
@@ -318,7 +318,7 @@ M.rename_menu = M.select.new({
           return
         end
 
-        local choice = M.delete_menu.choices()[item]
+        local choice = M.rename_menu.choices()[item]
         if not (choice and vim.is_callable(choice)) then
           vim.notify('Bad selection!', ERROR)
           return
@@ -439,6 +439,7 @@ M.open_menu = M.select.new({
       New = require('project.commands').cmds.ProjectAdd,
       Recents = M.recents_menu,
       Delete = M.delete_menu,
+      Rename = M.rename_menu,
       Config = require('project.commands').cmds.ProjectConfig,
       Historyfile = vim.cmd.ProjectHistory,
       Export = M.gen_export_prompt,
@@ -480,6 +481,7 @@ M.open_menu = M.select.new({
       'New',
       'Recents',
       'Delete',
+      'Rename',
       'Checkhealth',
       'Config',
       'Historyfile',

--- a/lua/project/popup.lua
+++ b/lua/project/popup.lua
@@ -527,7 +527,7 @@ M.session_menu = M.select.new({
         if item == 'Exit' then
           return item
         end
-        return vim.fn.fnamemodify(item, ':~') .. (vim.fn.isdirectory(item) == 1 and '/' or '')
+        return vim.fn.fnamemodify(item, ':~')
       end,
     }, function(item)
       if not item then
@@ -549,7 +549,17 @@ M.session_menu = M.select.new({
     end)
   end,
   choices = function()
-    local sessions = require('project.util.history').session_projects
+    local History = require('project.util.history')
+    local sessions = History.session_projects
+
+    if not History.legacy then
+      local session_paths = {} ---@type string[]
+      for _, v in ipairs(sessions) do
+        table.insert(session_paths, v.path)
+      end
+
+      sessions = vim.deepcopy(session_paths)
+    end
     local choices = { Exit = function() end }
     if vim.tbl_isempty(sessions) then
       return choices
@@ -560,7 +570,17 @@ M.session_menu = M.select.new({
     return choices
   end,
   choices_list = function()
-    local choices = vim.deepcopy(require('project.util.history').session_projects)
+    local History = require('project.util.history')
+    local choices = vim.deepcopy(History.session_projects)
+    if not History.legacy then
+      local session_paths = {} ---@type string[]
+      for _, v in ipairs(choices) do
+        table.insert(session_paths, v.path)
+      end
+
+      choices = vim.deepcopy(session_paths)
+    end
+
     table.insert(choices, 'Exit')
     return choices
   end,

--- a/lua/project/popup.lua
+++ b/lua/project/popup.lua
@@ -1,5 +1,5 @@
 ---@class Project.Popup.SelectChoices
----@field choices fun(): choices_dict: table<string, function>
+---@field choices fun(): choices_dict: table<string, fun(...?: any)>
 ---@field choices_list fun(exit?: boolean): choices: string[]
 
 ---@class Project.Popup.SelectSpec: Project.Popup.SelectChoices
@@ -128,6 +128,25 @@ local M = {}
 
 ---@class Project.Popup.Select
 M.select = {}
+
+---@param project string
+function M.rename_input(project)
+  Util.validate({
+    project = { project, { 'string' } },
+  })
+
+  vim.ui.input({
+    prompt = ('Input the new name for project %s'):format(
+      Util.rstrip('/', vim.fn.fnamemodify(project, ':p:~'))
+    ),
+  }, function(input)
+    if not input or input == '' then
+      return
+    end
+
+    require('project.util.history').rename_project(project, input)
+  end)
+end
 
 ---@param bang? boolean
 function M.gen_import_prompt(bang)
@@ -268,15 +287,66 @@ M.delete_menu = M.select.new({
     end)
   end,
   choices_list = function()
-    local recents = Util.reverse(require('project.util.history').get_recent_projects())
+    local recents = Util.reverse(require('project.util.history').get_recent_projects(true))
     table.insert(recents, 'Exit')
     return recents
   end,
   choices = function()
     local T = {} ---@type table<string, function>
-    for _, proj in ipairs(require('project.util.history').get_recent_projects()) do
+    for _, proj in ipairs(require('project.util.history').get_recent_projects(true)) do
       T[proj] = function()
         require('project.util.history').delete_project(proj)
+      end
+    end
+    T.Exit = function() end
+    return T
+  end,
+})
+
+M.rename_menu = M.select.new({
+  callback = function()
+    local choices_list = M.rename_menu.choices_list()
+    vim.ui.select(
+      choices_list,
+      { prompt = 'Select a project to rename:' },
+      function(item) ---@param item string
+        if not item then
+          return
+        end
+        if not vim.list_contains(choices_list, item) then
+          vim.notify('Bad selection!', ERROR)
+          return
+        end
+
+        local choice = M.delete_menu.choices()[item]
+        if not (choice and vim.is_callable(choice)) then
+          vim.notify('Bad selection!', ERROR)
+          return
+        end
+
+        vim.ui.input({
+          prompt = ('Input the new name for project %s'):format(
+            Util.rstrip('/', vim.fn.fnamemodify(item, ':p:~'))
+          ),
+        }, function(input)
+          if not input or input == '' then
+            return
+          end
+          choice(input)
+        end)
+      end
+    )
+  end,
+  choices_list = function()
+    local recents = Util.reverse(require('project.util.history').get_recent_projects(true))
+    table.insert(recents, 'Exit')
+    return recents
+  end,
+  choices = function()
+    local T = {} ---@type table<string, function>
+    for _, proj in ipairs(require('project.util.history').get_recent_projects(true)) do
+      T[proj] = function(name) ---@param name string
+        require('project.util.history').rename_project(proj, name)
       end
     end
     T.Exit = function() end
@@ -318,7 +388,7 @@ M.recents_menu = M.select.new({
     end)
   end,
   choices_list = function()
-    local choices_list = vim.deepcopy(require('project.util.history').get_recent_projects())
+    local choices_list = vim.deepcopy(require('project.util.history').get_recent_projects(true))
     if require('project.config').options.telescope.sort == 'newest' then
       choices_list = Util.reverse(choices_list)
     end

--- a/lua/project/popup.lua
+++ b/lua/project/popup.lua
@@ -3,7 +3,7 @@
 ---@field choices_list fun(exit?: boolean): choices: string[]
 
 ---@class Project.Popup.SelectSpec: Project.Popup.SelectChoices
----@field callback ProjectCmdFun
+---@field callback fun(ctx?: vim.api.keyset.create_user_command.command_args)
 
 local MODSTR = 'project.popup'
 local ERROR = vim.log.levels.ERROR
@@ -170,7 +170,7 @@ function M.gen_export_prompt(bang)
 end
 
 ---@param opts Project.Popup.SelectSpec
----@return Project.Popup.SelectChoices|ProjectCmdFun selector
+---@return Project.Popup.SelectChoices|fun(ctx?: vim.api.keyset.create_user_command.command_args) selector
 ---@nodiscard
 function M.select.new(opts)
   Util.validate({
@@ -184,23 +184,26 @@ function M.select.new(opts)
     error(('(%s.select.new): Empty args for constructor!'):format(MODSTR), ERROR)
   end
 
-  local T = setmetatable({ ---@type Project.Popup.SelectChoices|ProjectCmdFun
-    choices = opts.choices,
-    choices_list = opts.choices_list,
-  }, {
-    ---@param t Project.Popup.SelectChoices|ProjectCmdFun
-    ---@param k string
-    __index = function(t, k)
-      return rawget(t, k)
-    end,
-    __call = function(_, ctx) ---@param ctx? vim.api.keyset.create_user_command.command_args
-      if not ctx then
-        opts.callback()
-        return
-      end
-      opts.callback(ctx)
-    end,
-  })
+  local T = setmetatable(
+    { ---@type Project.Popup.SelectChoices|fun(ctx?: vim.api.keyset.create_user_command.command_args)
+      choices = opts.choices,
+      choices_list = opts.choices_list,
+    },
+    {
+      ---@param t Project.Popup.SelectChoices|fun(ctx?: vim.api.keyset.create_user_command.command_args)
+      ---@param k string
+      __index = function(t, k)
+        return rawget(t, k)
+      end,
+      __call = function(_, ctx) ---@param ctx? vim.api.keyset.create_user_command.command_args
+        if not ctx then
+          opts.callback()
+          return
+        end
+        opts.callback(ctx)
+      end,
+    }
+  )
   return T
 end
 
@@ -361,7 +364,7 @@ M.open_menu = M.select.new({
   end,
   choices = function()
     local Config = require('project.config')
-    local res = { ---@type table<string, ProjectCmdFun>
+    local res = { ---@type table<string, fun(ctx?: vim.api.keyset.create_user_command.command_args)>
       Session = M.session_menu,
       New = require('project.commands').cmds.ProjectAdd,
       Recents = M.recents_menu,

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -11,6 +11,62 @@ local ERROR = vim.log.levels.ERROR
 ---@class Project.Util
 local M = {}
 
+---@param s string
+---@param chars string
+---@param extra_allowed? { spaces?: boolean, newlines?: boolean }
+---@return boolean result
+function M.only_has_chars(s, chars, extra_allowed)
+  M.validate({
+    s = { s, { 'string' } },
+    chars = { chars, { 'string' } },
+    extra_allowed = { extra_allowed, { 'table', 'nil' }, true },
+  })
+  extra_allowed = extra_allowed or {}
+
+  M.validate({
+    ['extra_allowed.spaces'] = { extra_allowed.spaces, { 'boolean', 'nil' }, true },
+    ['extra_allowed.newlines'] = { extra_allowed.newlines, { 'boolean', 'nil' }, true },
+  })
+  if extra_allowed.spaces == nil then
+    extra_allowed.spaces = false
+  end
+  if extra_allowed.newlines == nil then
+    extra_allowed.newlines = false
+  end
+
+  if s == '' or chars == '' then
+    return false
+  end
+
+  local chars_list = M.dedup(vim.split(chars, '', { trimempty = true }))
+  local i = 1
+  while i <= #chars_list do
+    if chars_list[i] == '\n' then
+      table.remove(chars_list, i)
+    else
+      i = i + 1
+    end
+  end
+  if vim.tbl_isempty(chars_list) then
+    return false
+  end
+
+  if extra_allowed.spaces then
+    table.insert(chars_list, ' ')
+  end
+  if extra_allowed.newlines then
+    table.insert(chars_list, '\n')
+  end
+
+  local str_list = vim.split(s, '', { trimempty = false })
+  for _, c in ipairs(str_list) do
+    if not vim.list_contains(chars_list, c) then
+      return false
+    end
+  end
+  return true
+end
+
 ---@param list any[]
 ---@param t? type
 ---@return boolean result

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -639,9 +639,10 @@ end
 ---If the data passed to the function is not a table,
 ---an error will be raised.
 --- ---
----@param T table
----@param key? string
----@return table NT
+---@generic T
+---@param T T
+---@param key? string|integer
+---@return T NT
 ---@nodiscard
 function M.dedup(T, key)
   M.validate({

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -443,9 +443,8 @@ function M.executable(exe)
     return vim.fn.executable(exe) == 1
   end
 
-  local res = false
-
   ---@cast exe string[]
+  local res = false
   for _, v in ipairs(exe) do
     res = M.executable(v)
     if not res then

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -646,7 +646,7 @@ function M.dedup(T, key)
   return NT
 end
 
----@generic T: any
+---@generic T
 ---@param t type
 ---@param data T
 ---@param sep? string

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -455,27 +455,29 @@ function M.executable(exe)
   return res
 end
 
----@param tbl string[]
----@return string[] res
+---@param tbl string[]|ProjectHistoryEntry[]
+---@return string[]|ProjectHistoryEntry[] res
 ---@nodiscard
 function M.delete_duplicates(tbl)
   M.validate({ tbl = { tbl, { 'table' } } })
 
   local cache_dict = {} ---@type table<string, integer>
+  require('project.util.history').is_legacy(tbl)
+  local legacy = require('project.util.history').legacy
   for _, v in ipairs(tbl) do
-    local normalised_path = M.normalise_path(v)
-    if cache_dict[normalised_path] == nil then
+    local normalised_path = M.normalise_path(legacy and v or v.path)
+    if not cache_dict[normalised_path] then
       cache_dict[normalised_path] = 1
     else
       cache_dict[normalised_path] = cache_dict[normalised_path] + 1
     end
   end
 
-  local res = {} ---@type string[]
+  local res = {} ---@type string[]|ProjectHistoryEntry[]
   for _, v in ipairs(tbl) do
-    local normalised_path = M.normalise_path(v)
+    local normalised_path = M.normalise_path(legacy and v or v.path)
     if cache_dict[normalised_path] == 1 then
-      table.insert(res, normalised_path)
+      table.insert(res, legacy and normalised_path or { path = normalised_path, name = v.name })
     else
       cache_dict[normalised_path] = cache_dict[normalised_path] - 1
     end
@@ -607,22 +609,34 @@ end
 ---an error will be raised.
 --- ---
 ---@param T table
+---@param key? string
 ---@return table NT
 ---@nodiscard
-function M.dedup(T)
-  M.validate({ T = { T, { 'table' } } })
-
+function M.dedup(T, key)
+  M.validate({
+    T = { T, { 'table' } },
+    key = { key, { 'string', 'nil' }, true },
+  })
+  key = (key and key ~= '') and key or nil
   if vim.tbl_isempty(T) then
     return T
   end
 
   local NT = {}
+  local names = {} ---@type any[]
   for _, v in pairs(T) do
     local not_dup = false
     if M.is_type('table', v) then
-      not_dup = not vim.tbl_contains(NT, function(val)
-        return vim.deep_equal(val, v)
-      end, { predicate = true })
+      if not key then
+        not_dup = not vim.tbl_contains(NT, function(val)
+          return vim.deep_equal(val, v)
+        end, { predicate = true })
+      else
+        not_dup = not vim.list_contains(names, v[key])
+        if not_dup then
+          table.insert(names, v[key])
+        end
+      end
     else
       not_dup = not vim.list_contains(NT, v)
     end

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -11,6 +11,38 @@ local ERROR = vim.log.levels.ERROR
 ---@class Project.Util
 local M = {}
 
+---@param list any[]
+---@param t? type
+---@return boolean result
+function M.same_type_list(list, t)
+  M.validate({
+    list = { list, { 'table' } },
+    t = { t, { 'string', 'nil' }, true },
+  })
+  if
+    t
+    and not vim.list_contains(
+      { 'boolean', 'userdata', 'string', 'function', 'number', 'thread', 'table' },
+      t
+    )
+  then
+    error(('(%s.same_type_list): Invalid type `%s`'):format(t), ERROR)
+  end
+  if vim.tbl_isempty(list) or not vim.islist(list) then
+    return false
+  end
+
+  for _, v in ipairs(list) do
+    if not t then
+      t = type(v)
+    end
+    if not M.is_type(t, v) then
+      return false
+    end
+  end
+  return true
+end
+
 ---@overload fun(option: string|vim.wo|vim.bo): value: any
 ---@overload fun(option: string|vim.wo|vim.bo, param: 'scope', param_value: 'local'|'global'): value: any
 ---@overload fun(option: string|vim.wo|vim.bo, param: 'ft', param_value: string): value: any

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -552,9 +552,9 @@ function M.read_history()
   M.deserialize_history(data_str, name_list)
 end
 
----@param paths_only? boolean
----@param tilde? boolean
----@return string[]|ProjectHistoryEntry[] recents
+---@overload fun(): recents: ProjectHistoryEntry[]
+---@overload fun(paths_only?: false, tilde?: boolean): recents: ProjectHistoryEntry[]
+---@overload fun(paths_only: true, tilde?: boolean): recents: string[]
 function M.get_recent_projects(paths_only, tilde)
   Util.validate({
     paths_only = { paths_only, { 'boolean', 'nil' }, true },

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -8,13 +8,13 @@ local Path = require('project.util.path')
 local Log = require('project.util.log')
 
 ---@class ProjectHistoryEntry
----@field path string
 ---@field name string
+---@field path string
 
 ---@class Project.HistoryWin
 ---@field bufnr integer
----@field win integer
 ---@field tab integer
+---@field win integer
 
 ---@class Project.Util.History
 ---@field has_watch_setup? boolean
@@ -27,14 +27,40 @@ local Log = require('project.util.log')
 --- ---
 ---@field session_projects string[]|ProjectHistoryEntry[]
 ---@field window? Project.HistoryWin
-local History = {}
+local M = {}
 
-History.session_projects = {}
+M.session_projects = {}
+
+function M.migrate()
+  if M.recent_projects and Util.same_type_list(M.recent_projects, 'string') then
+    for i, v in ipairs(M.recent_projects) do
+      M.recent_projects[i] = {
+        path = v,
+        name = vim.fn.fnamemodify(v, ':p:h:h:t') .. '/' .. vim.fn.fnamemodify(v, ':p:h:t'),
+      }
+    end
+  end
+
+  if
+    not vim.tbl_isempty(M.session_projects)
+    and Util.same_type_list(M.session_projects, 'string')
+  then
+    for i, v in ipairs(M.session_projects) do
+      M.session_projects[i] = {
+        path = v,
+        name = vim.fn.fnamemodify(v, ':p:h:h:t') .. '/' .. vim.fn.fnamemodify(v, ':p:h:t'),
+      }
+    end
+  end
+
+  M.write_history()
+  M.read_history()
+end
 
 ---@param project string
 ---@param name string
-function History.rename_project(project, name)
-  if History.legacy then
+function M.rename_project(project, name)
+  if M.legacy then
     return
   end
 
@@ -45,7 +71,7 @@ function History.rename_project(project, name)
 
   local renamed = false
   local recent_i = 0
-  for i, proj in ipairs(History.recent_projects) do
+  for i, proj in ipairs(M.recent_projects) do
     ---@cast proj ProjectHistoryEntry
     if proj.path == project then
       recent_i = i
@@ -53,12 +79,12 @@ function History.rename_project(project, name)
     end
   end
   if recent_i ~= 0 then
-    History.recent_projects[recent_i].name = name
+    M.recent_projects[recent_i].name = name
     renamed = true
   end
 
   local session_i = 0
-  for i, proj in ipairs(History.session_projects) do
+  for i, proj in ipairs(M.session_projects) do
     ---@cast proj ProjectHistoryEntry
     if proj.path == project then
       session_i = i
@@ -66,7 +92,7 @@ function History.rename_project(project, name)
     end
   end
   if session_i ~= 0 then
-    History.session_projects[session_i].name = name
+    M.session_projects[session_i].name = name
     renamed = true
   end
 
@@ -75,12 +101,12 @@ function History.rename_project(project, name)
     vim.notify(('(%s.rename_project): Changed name successfully!'):format(MODSTR), INFO)
     Log.debug(('(%s.rename_project): Changed name successfully!'):format(MODSTR))
 
-    History.write_history()
+    M.write_history()
   end
 end
 
 ---@param force? boolean
-function History.clear_historyfile(force)
+function M.clear_historyfile(force)
   Util.validate({ force = { force, { 'boolean', 'nil' }, true } })
   if force == nil then
     force = false
@@ -117,15 +143,15 @@ function History.clear_historyfile(force)
   Log.warn(('(%s.clear_historyfile): History file cleared successfully.'):format(MODSTR))
   vim.notify('(project.nvim): History file cleared successfully', WARN)
 
-  History.recent_projects = {}
-  History.session_projects = {}
+  M.recent_projects = {}
+  M.session_projects = {}
   vim.g.project_historyfile_cleared = 1
 end
 
 ---@param mode uv.fs_open.flags
 ---@return integer|nil fd
 ---@return uv.fs_stat.result|nil stat
-function History.open_history(mode)
+function M.open_history(mode)
   Util.validate({ mode = { mode, { 'string', 'number' } } })
 
   local allowed_flags = {
@@ -174,7 +200,7 @@ end
 ---@param path string
 ---@param ind? integer|string|nil
 ---@param force_name? boolean
-function History.export_history_json(path, ind, force_name)
+function M.export_history_json(path, ind, force_name)
   Util.validate({
     path = { path, { 'string' } },
     ind = { ind, { 'string', 'number', 'nil' }, true },
@@ -241,7 +267,7 @@ function History.export_history_json(path, ind, force_name)
     end
   end
 
-  History.write_history()
+  M.write_history()
 
   if not Path.exists(path) then
     if Util.dir_exists(path) then
@@ -258,7 +284,7 @@ function History.export_history_json(path, ind, force_name)
     error(('(%s.export_history_json): File restricted! `%s`'):format(MODSTR, path), ERROR)
   end
 
-  local data = vim.json.encode(Util.reverse(History.get_recent_projects()), { indent = spc })
+  local data = vim.json.encode(Util.reverse(M.get_recent_projects()), { indent = spc })
 
   uv.fs_write(fd, data)
   uv.fs_close(fd)
@@ -270,7 +296,7 @@ end
 
 ---@param path string
 ---@param force_name? boolean
-function History.import_history_json(path, force_name)
+function M.import_history_json(path, force_name)
   Util.validate({
     path = { path, { 'string' } },
     force_name = { force_name, { 'boolean', 'nil' }, true },
@@ -320,8 +346,8 @@ function History.import_history_json(path, force_name)
     error(('(%s.import_history_json): JSON decoding failed! `%s`'):format(MODSTR, path), ERROR)
   end
 
-  History.recent_projects = Util.reverse(hist)
-  History.write_history()
+  M.recent_projects = Util.reverse(hist)
+  M.write_history()
 
   vim.notify(('Imported history from `%s`'):format(vim.fn.fnamemodify(path, ':~')), INFO, {
     title = 'project.nvim',
@@ -333,19 +359,18 @@ end
 ---@param session string
 ---@param found boolean
 ---@return boolean found
-function History.remove_session(session, found)
+function M.remove_session(session, found)
   Util.validate({
     session = { session, { 'string' } },
     found = { found, { 'boolean' } },
   })
 
   local i = 1
-  History.is_legacy(History.session_projects)
-  while i < #History.session_projects do
-    local recent = History.legacy and History.session_projects[i]
-      or History.session_projects[i].path
+  M.is_legacy(M.session_projects)
+  while i < #M.session_projects do
+    local recent = M.legacy and M.session_projects[i] or M.session_projects[i].path
     if recent == session then
-      table.remove(History.session_projects, i)
+      table.remove(M.session_projects, i)
       found = true
       i = i - 1
     else
@@ -359,15 +384,15 @@ end
 --- ---
 ---@param project string
 ---@return boolean found
-function History.remove_recent(project)
+function M.remove_recent(project)
   Util.validate({ project = { project, { 'string' } } })
 
   local found, i = false, 1 ---@type boolean, integer
-  History.is_legacy(History.recent_projects)
-  while i <= #History.recent_projects do
-    local recent = History.legacy and History.recent_projects[i] or History.recent_projects[i].path
+  M.is_legacy(M.recent_projects)
+  while i <= #M.recent_projects do
+    local recent = M.legacy and M.recent_projects[i] or M.recent_projects[i].path
     if recent == project then
-      table.remove(History.recent_projects, i)
+      table.remove(M.recent_projects, i)
       found = true
       i = i - 1
     else
@@ -381,7 +406,7 @@ end
 --- ---
 ---@param project string|Project.ActionEntry
 ---@param prompt? boolean
-function History.delete_project(project, prompt)
+function M.delete_project(project, prompt)
   Util.validate({
     project = { project, { 'string', 'table' } },
     prompt = { prompt, { 'boolean', 'nil' }, true },
@@ -395,7 +420,7 @@ function History.delete_project(project, prompt)
     Util.validate({ project_value = { project.value, { 'string' } } })
   end
 
-  if not History.recent_projects then
+  if not M.recent_projects then
     Log.error(('(%s.delete_project): `recent_projects` is nil! Aborting.'):format(MODSTR))
     vim.notify(('(%s.delete_project): `recent_projects` is nil! Aborting.'):format(MODSTR))
     return
@@ -410,13 +435,13 @@ function History.delete_project(project, prompt)
     end
   end
 
-  local found = History.remove_recent(proj)
-  found = History.remove_session(proj, found)
+  local found = M.remove_recent(proj)
+  found = M.remove_session(proj, found)
 
   if found then
     Log.info(('(%s.delete_project): Deleting project `%s`.'):format(MODSTR, proj))
     vim.notify(('(%s.delete_project): Deleting project `%s`.'):format(MODSTR, proj), INFO)
-    History.write_history()
+    M.write_history()
   end
 end
 
@@ -424,7 +449,7 @@ end
 --- ---
 ---@param history_data string
 ---@param name_data? string[]
-function History.deserialize_history(history_data, name_data)
+function M.deserialize_history(history_data, name_data)
   Util.validate({
     history_data = { history_data, { 'string' } },
     name_data = { name_data, { 'table', 'nil' }, true },
@@ -449,13 +474,13 @@ function History.deserialize_history(history_data, name_data)
 
     i = i + 1
   end
-  History.recent_projects = Util.delete_duplicates(projects)
+  M.recent_projects = Util.delete_duplicates(projects)
 end
 
 ---Only runs once.
 --- ---
-function History.setup_watch()
-  if History.has_watch_setup then
+function M.setup_watch()
+  if M.has_watch_setup then
     return
   end
 
@@ -467,14 +492,14 @@ function History.setup_watch()
     if err or not events.change then
       return
     end
-    History.recent_projects = nil
-    History.read_history()
+    M.recent_projects = nil
+    M.read_history()
   end)
-  History.has_watch_setup = true
+  M.has_watch_setup = true
 end
 
-function History.read_history()
-  local fd, stat = History.open_history('r')
+function M.read_history()
+  local fd, stat = M.open_history('r')
   if not stat then
     Log.error(('(%s.read_history): Stat for history file unavailable!'):format(MODSTR))
     if fd then
@@ -487,10 +512,10 @@ function History.read_history()
     return
   end
 
-  History.setup_watch()
+  M.setup_watch()
 
-  if stat.size == 0 and History.session_projects then
-    History.write_history()
+  if stat.size == 0 and M.session_projects then
+    M.write_history()
     return
   end
 
@@ -514,27 +539,23 @@ function History.read_history()
   end
 
   local data_str, name_list = '', {} ---@type string, string[]
-  History.is_legacy(data)
+  M.is_legacy(data)
   for _, v in ipairs(data) do
-    data_str = ('%s%s%s'):format(
-      data_str,
-      data_str == '' and '' or '\n',
-      History.legacy and v or v.path
-    )
+    data_str = ('%s%s%s'):format(data_str, data_str == '' and '' or '\n', M.legacy and v or v.path)
 
-    if not History.legacy then
+    if not M.legacy then
       ---@cast v ProjectHistoryEntry
       table.insert(name_list, v.name)
     end
   end
 
-  History.deserialize_history(data_str, name_list)
+  M.deserialize_history(data_str, name_list)
 end
 
 ---@param paths_only? boolean
 ---@param tilde? boolean
 ---@return string[]|ProjectHistoryEntry[] recents
-function History.get_recent_projects(paths_only, tilde)
+function M.get_recent_projects(paths_only, tilde)
   Util.validate({
     paths_only = { paths_only, { 'boolean', 'nil' }, true },
     tilde = { tilde, { 'boolean', 'nil' }, true },
@@ -547,18 +568,18 @@ function History.get_recent_projects(paths_only, tilde)
   end
 
   local tbl = {} ---@type string[]|ProjectHistoryEntry[]
-  if History.recent_projects then
-    vim.list_extend(tbl, History.recent_projects)
-    vim.list_extend(tbl, History.session_projects)
+  if M.recent_projects then
+    vim.list_extend(tbl, M.recent_projects)
+    vim.list_extend(tbl, M.session_projects)
   else
-    tbl = History.session_projects
+    tbl = M.session_projects
   end
   tbl = Util.delete_duplicates(tbl)
 
   local idx, removed = 1, false
-  History.is_legacy(tbl)
+  M.is_legacy(tbl)
   while idx <= #tbl do
-    local v = Util.rstrip('/', History.legacy and tbl[idx] or tbl[idx].path)
+    local v = Util.rstrip('/', M.legacy and tbl[idx] or tbl[idx].path)
     if not Path.exists(v) or Path.is_excluded(v) then
       table.remove(tbl, idx)
       removed = true
@@ -568,27 +589,24 @@ function History.get_recent_projects(paths_only, tilde)
   end
 
   if removed then
-    History.write_history()
+    M.write_history()
   end
 
   local recents = {} ---@type string[]|ProjectHistoryEntry[]
   for i, v in ipairs(tbl) do
-    local dir = History.legacy and v or v.path
+    local dir = M.legacy and v or v.path
     if Util.dir_exists(dir) then
       dir = tilde and vim.fn.fnamemodify(dir, ':~') or dir
-      table.insert(
-        recents,
-        (History.legacy or paths_only) and dir or { path = dir, name = tbl[i].name }
-      )
+      table.insert(recents, (M.legacy or paths_only) and dir or { path = dir, name = tbl[i].name })
     end
   end
-  return Util.dedup(recents, History.legacy and nil or 'name')
+  return Util.dedup(recents, M.legacy and nil or 'name')
 end
 
 ---Write projects to history file.
 --- ---
 ---@param path? string
-function History.write_history(path)
+function M.write_history(path)
   Util.validate({ path = { path, { 'string', 'nil' }, true } })
   path = Util.rstrip('/', vim.fn.fnamemodify(path or Path.historyfile, ':p'))
 
@@ -601,12 +619,12 @@ function History.write_history(path)
   end
 
   local historysize = require('project.config').options.historysize or 100
-  History.historysize = historysize > 0 and historysize or 100
+  M.historysize = historysize > 0 and historysize or 100
 
   local file_history = {} ---@type string[]|ProjectHistoryEntry[]
   local fd, stat ---@type integer|nil, uv.fs_stat.result|nil
   if path == Path.historyfile then
-    fd, stat = History.open_history('r')
+    fd, stat = M.open_history('r')
   else
     fd, stat = Path.open_file(path, 'r')
   end
@@ -618,7 +636,7 @@ function History.write_history(path)
     end
   end
 
-  local res, i = History.get_recent_projects(), 1
+  local res, i = M.get_recent_projects(), 1
   while i < #file_history do
     local proj = file_history[i]
     if
@@ -648,9 +666,8 @@ function History.write_history(path)
   end
 
   local tbl_out = vim.deepcopy(file_history)
-  if History.historysize and History.historysize > 0 then
-    tbl_out = #res > History.historysize and vim.list_slice(res, #res - History.historysize, #res)
-      or res
+  if M.historysize and M.historysize > 0 then
+    tbl_out = #res > M.historysize and vim.list_slice(res, #res - M.historysize, #res) or res
   end
 
   if vim.tbl_isempty(tbl_out) then
@@ -661,7 +678,7 @@ function History.write_history(path)
   end
 
   if path == Path.historyfile then
-    fd = History.open_history('w')
+    fd = M.open_history('w')
   else
     fd = Path.open_file(path, 'w')
   end
@@ -683,7 +700,8 @@ function History.write_history(path)
 end
 
 ---@param data string[]|ProjectHistoryEntry[]
-function History.is_legacy(data)
+---@return boolean legacy
+function M.is_legacy(data)
   Util.validate({ data = { data, { 'table' } } })
 
   local is_legacy = nil ---@type boolean|nil
@@ -705,10 +723,11 @@ function History.is_legacy(data)
     end
   end
 
-  History.legacy = is_legacy
+  M.legacy = is_legacy
+  return is_legacy
 end
 
-function History.open_win()
+function M.open_win()
   if not Path.historyfile then
     return
   end
@@ -716,11 +735,11 @@ function History.open_win()
     Log.error(('(%s.open_win): Bad historyfile path!'):format(MODSTR))
     error(('(%s.open_win): Bad historyfile path!'):format(MODSTR), ERROR)
   end
-  if History.window then
+  if M.window then
     return
   end
 
-  local fd, stat = History.open_history('r')
+  local fd, stat = M.open_history('r')
   if not stat then
     Log.error(('(%s.open_win): Stat for history file unavailable!'):format(MODSTR))
     if fd then
@@ -742,15 +761,15 @@ function History.open_win()
 
   vim.cmd.tabnew()
   vim.schedule(function()
-    History.window = {
+    M.window = {
       bufnr = vim.api.nvim_get_current_buf(),
       win = vim.api.nvim_get_current_win(),
       tab = vim.api.nvim_get_current_tabpage(),
     }
 
     local lines = {} ---@type string[]
-    History.is_legacy(data)
-    if History.legacy then
+    M.is_legacy(data)
+    if M.legacy then
       ---@cast data string[]
       lines = vim.deepcopy(data)
     else
@@ -760,45 +779,45 @@ function History.open_win()
       end
     end
 
-    vim.api.nvim_buf_set_lines(History.window.bufnr, 0, 1, true, Util.reverse(lines))
-    vim.api.nvim_buf_set_name(History.window.bufnr, 'Project History')
+    vim.api.nvim_buf_set_lines(M.window.bufnr, 0, 1, true, Util.reverse(lines))
+    vim.api.nvim_buf_set_name(M.window.bufnr, 'Project History')
 
-    Util.optset('signcolumn', 'no', 'win', History.window.win)
-    Util.optset('list', false, 'win', History.window.win)
-    Util.optset('number', false, 'win', History.window.win)
-    Util.optset('wrap', false, 'win', History.window.win)
-    Util.optset('colorcolumn', '', 'win', History.window.win)
-    Util.optset('filetype', '', 'buf', History.window.bufnr)
-    Util.optset('fileencoding', 'utf-8', 'buf', History.window.bufnr)
-    Util.optset('buftype', 'nowrite', 'buf', History.window.bufnr)
-    Util.optset('modifiable', false, 'buf', History.window.bufnr)
+    Util.optset('signcolumn', 'no', 'win', M.window.win)
+    Util.optset('list', false, 'win', M.window.win)
+    Util.optset('number', false, 'win', M.window.win)
+    Util.optset('wrap', false, 'win', M.window.win)
+    Util.optset('colorcolumn', '', 'win', M.window.win)
+    Util.optset('filetype', '', 'buf', M.window.bufnr)
+    Util.optset('fileencoding', 'utf-8', 'buf', M.window.bufnr)
+    Util.optset('buftype', 'nowrite', 'buf', M.window.bufnr)
+    Util.optset('modifiable', false, 'buf', M.window.bufnr)
 
-    vim.keymap.set('n', 'q', History.close_win, {
-      buffer = History.window.bufnr,
+    vim.keymap.set('n', 'q', M.close_win, {
+      buffer = M.window.bufnr,
       noremap = true,
       silent = true,
     })
   end)
 end
 
-function History.close_win()
-  if not History.window then
+function M.close_win()
+  if not M.window then
     return
   end
 
-  pcall(vim.api.nvim_buf_delete, History.window.bufnr, { force = true })
-  pcall(vim.api.nvim_cmd, { cmd = 'tabclose', range = { History.window.tab } }, { output = false })
-  History.window = nil
+  pcall(vim.api.nvim_buf_delete, M.window.bufnr, { force = true })
+  pcall(vim.api.nvim_cmd, { cmd = 'tabclose', range = { M.window.tab } }, { output = false })
+  M.window = nil
 end
 
-function History.toggle_win()
-  if not History.window then
-    History.open_win()
+function M.toggle_win()
+  if not M.window then
+    M.open_win()
     return
   end
 
-  History.close_win()
+  M.close_win()
 end
 
-return History
+return M
 -- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -17,18 +17,67 @@ local Log = require('project.util.log')
 ---@field tab integer
 
 ---@class Project.Util.History
+---@field has_watch_setup? boolean
+---@field historysize? integer
+---@field legacy? boolean
 ---Projects from previous neovim sessions.
 --- ---
 ---@field recent_projects? string[]|ProjectHistoryEntry[]
----@field has_watch_setup? boolean
----@field historysize? integer
----@field window? Project.HistoryWin
----@field legacy? boolean
-local History = {}
-
 ---Projects from current neovim session.
 --- ---
-History.session_projects = {} ---@type string[]|ProjectHistoryEntry[]
+---@field session_projects string[]|ProjectHistoryEntry[]
+---@field window? Project.HistoryWin
+local History = {}
+
+History.session_projects = {}
+
+---@param project string
+---@param name string
+function History.rename_project(project, name)
+  if History.legacy then
+    return
+  end
+
+  Util.validate({
+    project = { project, { 'string' } },
+    name = { name, { 'string' } },
+  })
+
+  local renamed = false
+  local recent_i = 0
+  for i, proj in ipairs(History.recent_projects) do
+    ---@cast proj ProjectHistoryEntry
+    if proj.path == project then
+      recent_i = i
+      break
+    end
+  end
+  if recent_i ~= 0 then
+    History.recent_projects[recent_i].name = name
+    renamed = true
+  end
+
+  local session_i = 0
+  for i, proj in ipairs(History.session_projects) do
+    ---@cast proj ProjectHistoryEntry
+    if proj.path == project then
+      session_i = i
+      break
+    end
+  end
+  if session_i ~= 0 then
+    History.session_projects[session_i].name = name
+    renamed = true
+  end
+
+  if renamed then
+    -- TODO: Include old name and/or more information
+    vim.notify(('(%s.rename_project): Changed name successfully!'):format(MODSTR), INFO)
+    Log.debug(('(%s.rename_project): Changed name successfully!'):format(MODSTR))
+
+    History.write_history()
+  end
+end
 
 ---@param force? boolean
 function History.clear_historyfile(force)
@@ -482,12 +531,19 @@ function History.read_history()
   History.deserialize_history(data_str, name_list)
 end
 
+---@param paths_only? boolean
 ---@param tilde? boolean
 ---@return string[]|ProjectHistoryEntry[] recents
-function History.get_recent_projects(tilde)
-  Util.validate({ tilde = { tilde, { 'boolean', 'nil' }, true } })
+function History.get_recent_projects(paths_only, tilde)
+  Util.validate({
+    paths_only = { paths_only, { 'boolean', 'nil' }, true },
+    tilde = { tilde, { 'boolean', 'nil' }, true },
+  })
   if tilde == nil then
     tilde = false
+  end
+  if paths_only == nil then
+    paths_only = false
   end
 
   local tbl = {} ---@type string[]|ProjectHistoryEntry[]
@@ -520,7 +576,10 @@ function History.get_recent_projects(tilde)
     local dir = History.legacy and v or v.path
     if Util.dir_exists(dir) then
       dir = tilde and vim.fn.fnamemodify(dir, ':~') or dir
-      table.insert(recents, History.legacy and dir or { path = dir, name = tbl[i].name })
+      table.insert(
+        recents,
+        (History.legacy or paths_only) and dir or { path = dir, name = tbl[i].name }
+      )
     end
   end
   return Util.dedup(recents, History.legacy and nil or 'name')

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -723,8 +723,6 @@ function M.is_legacy(data)
     end
   end
 
-  M.legacy = is_legacy
-
   if is_legacy and vim.g.project_migration_notified ~= 1 then
     vim.g.project_migration_notified = 1
     vim.notify(
@@ -736,7 +734,34 @@ If you encounter any bugs please raise an issue and it will be dealt with ASAP.]
     )
   end
 
+  M.legacy = is_legacy
   return is_legacy
+end
+
+---@param search 'session'|'recent'
+---@param project string
+---@param field 'path'|'name'
+---@return string|nil entry_field
+function M.find_entry(search, project, field)
+  Util.validate({
+    search = { search, { 'string' } },
+    project = { project, { 'string' } },
+    field = { field, { 'string' } },
+  })
+  if not vim.list_contains({ 'recent', 'session' }, search) then
+    return
+  end
+  if not (vim.list_contains({ 'path', 'name' }, field) and M.legacy) then
+    return
+  end
+
+  local tbl = vim.deepcopy(search == 'session' and M.session_projects or M.recent_projects) --[[@as ProjectHistoryEntry[]\]]
+  for _, v in ipairs(tbl) do
+    ---@cast v ProjectHistoryEntry
+    if v.path == Util.rstrip('/', vim.fn.fnamemodify(project, ':p')) or v.name == project then
+      return v[field]
+    end
+  end
 end
 
 function M.open_win()

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -751,13 +751,12 @@ function M.find_entry(search, project, field)
   if not vim.list_contains({ 'recent', 'session' }, search) then
     return
   end
-  if not (vim.list_contains({ 'path', 'name' }, field) and M.legacy) then
+  if not (vim.list_contains({ 'path', 'name' }, field) and not M.legacy) then
     return
   end
 
-  local tbl = vim.deepcopy(search == 'session' and M.session_projects or M.recent_projects) --[[@as ProjectHistoryEntry[]\]]
+  local tbl = search == 'session' and M.session_projects or M.recent_projects --[[@as ProjectHistoryEntry[]\]]
   for _, v in ipairs(tbl) do
-    ---@cast v ProjectHistoryEntry
     if v.path == Util.rstrip('/', vim.fn.fnamemodify(project, ':p')) or v.name == project then
       return v[field]
     end

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -618,7 +618,7 @@ function M.write_history(path)
     end
   end
 
-  local historysize = require('project.config').options.historysize or 100
+  local historysize = require('project.config').options.history.size or 100
   M.historysize = historysize > 0 and historysize or 100
 
   local file_history = {} ---@type string[]|ProjectHistoryEntry[]

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -7,6 +7,10 @@ local Util = require('project.util')
 local Path = require('project.util.path')
 local Log = require('project.util.log')
 
+---@class ProjectHistoryEntry
+---@field path string
+---@field name string
+
 ---@class Project.HistoryWin
 ---@field bufnr integer
 ---@field win integer
@@ -15,15 +19,16 @@ local Log = require('project.util.log')
 ---@class Project.Util.History
 ---Projects from previous neovim sessions.
 --- ---
----@field recent_projects? string[]
+---@field recent_projects? string[]|ProjectHistoryEntry[]
 ---@field has_watch_setup? boolean
 ---@field historysize? integer
 ---@field window? Project.HistoryWin
+---@field legacy? boolean
 local History = {}
 
 ---Projects from current neovim session.
 --- ---
-History.session_projects = {} ---@type string[]
+History.session_projects = {} ---@type string[]|ProjectHistoryEntry[]
 
 ---@param force? boolean
 function History.clear_historyfile(force)
@@ -286,8 +291,11 @@ function History.remove_session(session, found)
   })
 
   local i = 1
+  History.is_legacy(History.session_projects)
   while i < #History.session_projects do
-    if History.session_projects[i] == session then
+    local recent = History.legacy and History.session_projects[i]
+      or History.session_projects[i].path
+    if recent == session then
       table.remove(History.session_projects, i)
       found = true
       i = i - 1
@@ -306,8 +314,10 @@ function History.remove_recent(project)
   Util.validate({ project = { project, { 'string' } } })
 
   local found, i = false, 1 ---@type boolean, integer
+  History.is_legacy(History.recent_projects)
   while i <= #History.recent_projects do
-    if History.recent_projects[i] == project then
+    local recent = History.legacy and History.recent_projects[i] or History.recent_projects[i].path
+    if recent == project then
       table.remove(History.recent_projects, i)
       found = true
       i = i - 1
@@ -364,14 +374,31 @@ end
 ---Splits data into table.
 --- ---
 ---@param history_data string
-function History.deserialize_history(history_data)
-  Util.validate({ history_data = { history_data, { 'string' } } })
+---@param name_data? string[]
+function History.deserialize_history(history_data, name_data)
+  Util.validate({
+    history_data = { history_data, { 'string' } },
+    name_data = { name_data, { 'table', 'nil' }, true },
+  })
+  name_data = (name_data and not vim.tbl_isempty(name_data)) and name_data or nil
 
-  local projects = {} ---@type string[]
+  local projects = {} ---@type string[]|ProjectHistoryEntry[]
+  local i = 1
   for s in history_data:gmatch('[^\r\n]+') do
+    local entry = name_data and {} or '' ---@type string|ProjectHistoryEntry
     if not Path.is_excluded(s) and Path.exists(s) then
-      table.insert(projects, s)
+      if not name_data then
+        ---@cast entry string
+        entry = s
+      else
+        ---@cast entry ProjectHistoryEntry
+        entry.path = s
+        entry.name = name_data[i]
+      end
+      table.insert(projects, entry)
     end
+
+    i = i + 1
   end
   History.recent_projects = Util.delete_duplicates(projects)
 end
@@ -418,7 +445,7 @@ function History.read_history()
     return
   end
 
-  ---@type boolean, string[]|nil
+  ---@type boolean, string[]|ProjectHistoryEntry[]|nil
   local ok, data = pcall(vim.json.decode, uv.fs_read(fd, stat.size))
   uv.fs_close(fd)
   if not (ok and data) then
@@ -437,54 +464,66 @@ function History.read_history()
     return
   end
 
-  local data_str = ''
-  for _, v in pairs(data) do
-    data_str = ('%s%s%s'):format(data_str, data_str == '' and '' or '\n', v)
+  local data_str, name_list = '', {} ---@type string, string[]
+  History.is_legacy(data)
+  for _, v in ipairs(data) do
+    data_str = ('%s%s%s'):format(
+      data_str,
+      data_str == '' and '' or '\n',
+      History.legacy and v or v.path
+    )
+
+    if not History.legacy then
+      ---@cast v ProjectHistoryEntry
+      table.insert(name_list, v.name)
+    end
   end
 
-  History.deserialize_history(data_str)
+  History.deserialize_history(data_str, name_list)
 end
 
 ---@param tilde? boolean
----@return string[] recents
+---@return string[]|ProjectHistoryEntry[] recents
 function History.get_recent_projects(tilde)
   Util.validate({ tilde = { tilde, { 'boolean', 'nil' }, true } })
   if tilde == nil then
     tilde = false
   end
 
-  local tbl = {} ---@type string[]
+  local tbl = {} ---@type string[]|ProjectHistoryEntry[]
   if History.recent_projects then
     vim.list_extend(tbl, History.recent_projects)
     vim.list_extend(tbl, History.session_projects)
   else
     tbl = History.session_projects
   end
-  tbl = Util.delete_duplicates(vim.deepcopy(tbl))
+  tbl = Util.delete_duplicates(tbl)
 
-  local i, removed = 1, false
-  while i <= #tbl do
-    local v = Util.rstrip('/', tbl[i])
+  local idx, removed = 1, false
+  History.is_legacy(tbl)
+  while idx <= #tbl do
+    local v = Util.rstrip('/', History.legacy and tbl[idx] or tbl[idx].path)
     if not Path.exists(v) or Path.is_excluded(v) then
-      table.remove(tbl, i)
+      table.remove(tbl, idx)
       removed = true
-      i = i - 1
+      idx = idx - 1
     end
-
-    i = i + 1
+    idx = idx + 1
   end
 
   if removed then
     History.write_history()
   end
 
-  local recents = {} ---@type string[]
-  for _, dir in ipairs(tbl) do
+  local recents = {} ---@type string[]|ProjectHistoryEntry[]
+  for i, v in ipairs(tbl) do
+    local dir = History.legacy and v or v.path
     if Util.dir_exists(dir) then
-      table.insert(recents, tilde and vim.fn.fnamemodify(dir, ':~') or dir)
+      dir = tilde and vim.fn.fnamemodify(dir, ':~') or dir
+      table.insert(recents, History.legacy and dir or { path = dir, name = tbl[i].name })
     end
   end
-  return Util.dedup(recents)
+  return Util.dedup(recents, History.legacy and nil or 'name')
 end
 
 ---Write projects to history file.
@@ -495,15 +534,17 @@ function History.write_history(path)
   path = Util.rstrip('/', vim.fn.fnamemodify(path or Path.historyfile, ':p'))
 
   if not Path.exists(path) then
-    if vim.fn.writefile({ '[', ']' }, path) ~= 0 then
+    local write_res = vim.fn.writefile({ '[', ']' }, path)
+    if write_res ~= 0 then
       Log.error(('(%s.write_history): History file unavailable!'):format(MODSTR))
       error(('(%s.write_history): History file unavailable!'):format(MODSTR), ERROR)
     end
   end
 
-  History.historysize = require('project.config').options.historysize or 100
+  local historysize = require('project.config').options.historysize or 100
+  History.historysize = historysize > 0 and historysize or 100
 
-  local file_history = {} ---@type string[]
+  local file_history = {} ---@type string[]|ProjectHistoryEntry[]
   local fd, stat ---@type integer|nil, uv.fs_stat.result|nil
   if path == Path.historyfile then
     fd, stat = History.open_history('r')
@@ -514,15 +555,21 @@ function History.write_history(path)
     local data = uv.fs_read(fd, stat.size)
     uv.fs_close(fd)
     if data then
-      file_history = vim.json.decode(data) ---@type string[]
+      file_history = vim.json.decode(data) --[[@as string[]|ProjectHistoryEntry[]\]]
     end
   end
 
-  local res = History.get_recent_projects()
-  local i = 1
+  local res, i = History.get_recent_projects(), 1
   while i < #file_history do
     local proj = file_history[i]
-    if vim.list_contains(file_history, proj) and not vim.list_contains(res, proj) then
+    if
+      vim.tbl_contains(file_history, function(val)
+        return vim.deep_equal(val, proj)
+      end, { predicate = true })
+      and not vim.tbl_contains(res, function(val)
+        return vim.deep_equal(val, proj)
+      end, { predicate = true })
+    then
       table.remove(file_history, i)
       i = i > 1 and i - 1 or i
     else
@@ -531,7 +578,11 @@ function History.write_history(path)
   end
   while i < #res do
     local proj = res[i]
-    if not vim.list_contains(file_history, proj) then
+    if
+      not vim.tbl_contains(file_history, function(val)
+        return vim.deep_equal(val, proj)
+      end, { predicate = true })
+    then
       table.insert(file_history, i)
     end
     i = i + 1
@@ -572,6 +623,32 @@ function History.write_history(path)
   uv.fs_close(fd)
 end
 
+---@param data string[]|ProjectHistoryEntry[]
+function History.is_legacy(data)
+  Util.validate({ data = { data, { 'table' } } })
+
+  local is_legacy = nil ---@type boolean|nil
+  for _, entry in ipairs(data) do
+    if is_legacy == nil then
+      is_legacy = Util.is_type('string', entry)
+    end
+
+    if is_legacy then
+      ---@cast entry string
+      Util.validate({ entry = { entry, { 'string' } } })
+    else
+      ---@cast entry ProjectHistoryEntry
+      Util.validate({
+        entry = { entry, { 'table' } },
+        ['entry.path'] = { entry.path, { 'string' } },
+        ['entry.name'] = { entry.name, { 'string' } },
+      })
+    end
+  end
+
+  History.legacy = is_legacy
+end
+
 function History.open_win()
   if not Path.historyfile then
     return
@@ -597,9 +674,9 @@ function History.open_win()
     return
   end
 
-  ---@type boolean, string[]
+  ---@type boolean, string[]|ProjectHistoryEntry[]|nil
   local ok, data = pcall(vim.json.decode, uv.fs_read(fd, stat.size))
-  if not ok then
+  if not (ok and data) then
     uv.fs_close(fd)
     return
   end
@@ -612,7 +689,19 @@ function History.open_win()
       tab = vim.api.nvim_get_current_tabpage(),
     }
 
-    vim.api.nvim_buf_set_lines(History.window.bufnr, 0, 1, true, Util.reverse(data))
+    local lines = {} ---@type string[]
+    History.is_legacy(data)
+    if History.legacy then
+      ---@cast data string[]
+      lines = vim.deepcopy(data)
+    else
+      ---@cast data ProjectHistoryEntry[]
+      for _, entry in ipairs(data) do
+        table.insert(lines, entry.name)
+      end
+    end
+
+    vim.api.nvim_buf_set_lines(History.window.bufnr, 0, 1, true, Util.reverse(lines))
     vim.api.nvim_buf_set_name(History.window.bufnr, 'Project History')
 
     Util.optset('signcolumn', 'no', 'win', History.window.win)

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -724,6 +724,18 @@ function M.is_legacy(data)
   end
 
   M.legacy = is_legacy
+
+  if is_legacy and vim.g.project_migration_notified ~= 1 then
+    vim.g.project_migration_notified = 1
+    vim.notify(
+      [[project.nvim - Your history needs to be migrated to the new spec!
+To migrate simply run `:ProjectHistory migrate` in your cmdline.
+
+If you encounter any bugs please raise an issue and it will be dealt with ASAP.]],
+      WARN
+    )
+  end
+
   return is_legacy
 end
 

--- a/lua/project/util/path.lua
+++ b/lua/project/util/path.lua
@@ -14,25 +14,25 @@ local Config = require('project.config')
 ---The project history file.
 --- ---
 ---@field historyfile? string
-local Path = {}
+local M = {}
 
-Path.last_dir_cache = '' ---@type string
-Path.curr_dir_cache = {} ---@type string[]
-Path.exists = Util.path_exists
+M.last_dir_cache = '' ---@type string
+M.curr_dir_cache = {} ---@type string[]
+M.exists = Util.path_exists
 
 ---@param path string
 ---@param flags uv.fs_open.flags
 ---@param mode? integer
 ---@return integer|nil fd
 ---@return uv.fs_stat.result|nil stat
-function Path.open_file(path, flags, mode)
+function M.open_file(path, flags, mode)
   Util.validate({
     path = { path, { 'string' } },
     flags = { flags, { 'string', 'number' } },
     mode = { mode, { 'number', 'nil' }, true },
   })
   mode = (mode and Util.is_int(mode)) and mode or tonumber('644', 8)
-  if not Path.exists(path) then
+  if not M.exists(path) then
     return
   end
 
@@ -48,7 +48,7 @@ end
 ---@param dir string
 ---@return boolean verified
 ---@nodiscard
-function Path.verify_owner(dir)
+function M.verify_owner(dir)
   Util.validate({ dir = { dir, { 'string' } } })
 
   local Log = require('project.util.log')
@@ -68,7 +68,7 @@ end
 
 ---@param dir string
 ---@return boolean excluded
-function Path.is_excluded(dir)
+function M.is_excluded(dir)
   Util.validate({ dir = { dir, { 'string' } } })
 
   local exclude_dirs = Config.options.exclude_dirs
@@ -83,7 +83,7 @@ end
 ---@param dir string
 ---@param identifier string
 ---@return boolean is
-function Path.is(dir, identifier)
+function M.is(dir, identifier)
   Util.validate({
     dir = { dir, { 'string' } },
     identifier = { identifier, { 'string' } },
@@ -94,7 +94,7 @@ end
 
 ---@param path_str string
 ---@return string parent
-function Path.get_parent(path_str)
+function M.get_parent(path_str)
   Util.validate({ path_str = { path_str, { 'string' } } })
 
   local parent = path_str:match('^(.*)/') ---@type string
@@ -102,11 +102,11 @@ function Path.get_parent(path_str)
 end
 
 ---@param file_dir string
-function Path.get_files(file_dir)
+function M.get_files(file_dir)
   Util.validate({ file_dir = { file_dir, { 'string' } } })
 
-  Path.last_dir_cache = file_dir
-  Path.curr_dir_cache = {}
+  M.last_dir_cache = file_dir
+  M.curr_dir_cache = {}
   local dir = uv.fs_scandir(file_dir)
   if not dir then
     return
@@ -116,25 +116,25 @@ function Path.get_files(file_dir)
     if not file then
       return
     end
-    table.insert(Path.curr_dir_cache, file)
+    table.insert(M.curr_dir_cache, file)
   end
 end
 
 ---@param dir string
 ---@param identifier string
 ---@return boolean has
-function Path.has(dir, identifier)
+function M.has(dir, identifier)
   Util.validate({
     dir = { dir, { 'string' } },
     identifier = { identifier, { 'string' } },
   })
 
-  if Path.last_dir_cache ~= dir then
-    Path.get_files(dir)
+  if M.last_dir_cache ~= dir then
+    M.get_files(dir)
   end
 
   local pattern = require('project.util.globtopattern').globtopattern(identifier)
-  for _, file in ipairs(Path.curr_dir_cache) do
+  for _, file in ipairs(M.curr_dir_cache) do
     if file:match(pattern) then
       return true
     end
@@ -145,19 +145,19 @@ end
 ---@param dir string
 ---@param identifier string
 ---@return boolean is_sub
-function Path.sub(dir, identifier)
+function M.sub(dir, identifier)
   Util.validate({
     dir = { dir, { 'string' } },
     identifier = { identifier, { 'string' } },
   })
 
-  local path_str = Path.get_parent(dir)
+  local path_str = M.get_parent(dir)
   local current
   while true do
-    if Path.is(path_str, identifier) then
+    if M.is(path_str, identifier) then
       return true
     end
-    current, path_str = path_str, Path.get_parent(path_str)
+    current, path_str = path_str, M.get_parent(path_str)
     if current == path_str then
       return false
     end
@@ -167,28 +167,28 @@ end
 ---@param dir string
 ---@param identifier string
 ---@return boolean is_child
-function Path.child(dir, identifier)
+function M.child(dir, identifier)
   Util.validate({
     dir = { dir, { 'string' } },
     identifier = { identifier, { 'string' } },
   })
 
-  return Path.is(Path.get_parent(dir), identifier)
+  return M.is(M.get_parent(dir), identifier)
 end
 
 ---@param dir string
 ---@param pattern string
 ---@return boolean matches
-function Path.match(dir, pattern)
+function M.match(dir, pattern)
   Util.validate({
     dir = { dir, { 'string' } },
     pattern = { pattern, { 'string' } },
   })
 
   local SWITCH = {
-    ['='] = Path.is,
-    ['^'] = Path.sub,
-    ['>'] = Path.child,
+    ['='] = M.is,
+    ['^'] = M.sub,
+    ['>'] = M.child,
   }
   local first_char = pattern:sub(1, 1)
   for char, case in pairs(SWITCH) do
@@ -196,15 +196,15 @@ function Path.match(dir, pattern)
       return case(dir, pattern:sub(2))
     end
   end
-  return Path.has(dir, pattern)
+  return M.has(dir, pattern)
 end
 
 ---@param path string|nil
-function Path.create_path(path)
+function M.create_path(path)
   Util.validate({ path = { path, { 'string', 'nil' }, true } })
-  path = path or Path.projectpath --[[@as string]]
+  path = path or M.projectpath --[[@as string]]
 
-  if not Path.exists(path) then
+  if not M.exists(path) then
     require('project.util.log').debug(
       ('(%s.create_path): Creating directory `%s`.'):format(MODSTR, path)
     )
@@ -215,7 +215,7 @@ end
 ---@param dir string
 ---@return string|nil dir
 ---@return string|nil pattern
-function Path.root_included(dir)
+function M.root_included(dir)
   Util.validate({ dir = { dir, { 'string' } } })
 
   while true do ---Breadth-First search
@@ -224,14 +224,14 @@ function Path.root_included(dir)
       if pattern:sub(1, 1) == '!' then
         excluded, pattern = true, pattern:sub(2)
       end
-      if Path.match(dir, pattern) then
+      if M.match(dir, pattern) then
         if not excluded then
           return dir, ('pattern %s'):format(pattern)
         end
         break
       end
     end
-    local parent = Path.get_parent(dir)
+    local parent = M.get_parent(dir)
     if not parent or parent == dir then
       return
     end
@@ -244,15 +244,39 @@ function Path.root_included(dir)
   end
 end
 
----@param datapath string
-function Path.init(datapath)
-  Util.validate({ datapath = { datapath, { 'string' } } })
+---@param save_dir string
+---@param save_file string
+function M.init(save_dir, save_file)
+  local Defaults = require('project.config.defaults')
+  Util.validate({
+    save_dir = { save_dir, { 'string' } },
+    save_file = { save_file, { 'string' } },
+  })
 
-  datapath = Path.exists(datapath) and datapath or vim.fn.stdpath('data')
-  Path.datapath = datapath
-  Path.projectpath = ('%s/project_nvim'):format(Path.datapath)
-  Path.historyfile = ('%s/project_history.json'):format(Path.projectpath)
+  M.datapath = save_dir
+  if not (vim.fn.mkdir(M.datapath, 'p') == 1 or M.exists(M.datapath)) then
+    M.datapath = Defaults.history.save_dir
+    if not (vim.fn.mkdir(M.datapath, 'p') == 1 or M.exists(M.datapath)) then
+      error('(%s.init): Unable to create history directory!', ERROR)
+    end
+  end
+
+  M.projectpath = vim.fs.joinpath(M.datapath, 'project_nvim')
+  if not (M.exists(M.projectpath) or vim.fn.mkdir(M.projectpath, 'p') == 1) then
+    error('(%s.init): Unable to create history subdirectory!', ERROR)
+  end
+
+  M.historyfile = vim.fs.joinpath(M.projectpath, save_file)
+  if not M.exists(M.historyfile) then
+    local fd = uv.fs_open(M.historyfile, 'w', tonumber('644', 8))
+    if not fd then
+      error('(%s.init): Unable to create history file!', ERROR)
+    end
+
+    uv.fs_write(fd, '')
+    uv.fs_close(fd)
+  end
 end
 
-return Path
+return M
 -- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/telescope/_extensions/projects/actions.lua
+++ b/lua/telescope/_extensions/projects/actions.lua
@@ -48,7 +48,7 @@ function M.delete_project(prompt_bufnr)
   Log.debug(('(%s.delete_project): Refreshing prompt `%s`.'):format(MODSTR, prompt_bufnr))
   State.get_current_picker(prompt_bufnr):refresh(
     (function()
-      local results = History.get_recent_projects()
+      local results = History.get_recent_projects(true)
       if Config.options.telescope.sort == 'newest' then
         Log.debug(('(%s.create_finder): Sorting order to `newest`.'):format(MODSTR))
         results = Util.reverse(results)

--- a/lua/telescope/_extensions/projects/util.lua
+++ b/lua/telescope/_extensions/projects/util.lua
@@ -17,18 +17,18 @@ local Finders = require('telescope.finders')
 local Entry_display = require('telescope.pickers.entry_display')
 
 ---@class Project.Telescope.Util
-local M = {
-  ---@param entry { name: string, value: string, display: function, index: integer, ordinal: string }
-  make_display = function(entry)
-    Log.debug(
-      ('(%s.make_display): Creating display. Entry values: %s'):format(MODSTR, vim.inspect(entry))
-    )
-    return Entry_display.create({
-      separator = ' ',
-      items = { { width = 30 }, { remaining = true } },
-    })({ entry.name, { entry.value, 'Comment' } })
-  end,
-}
+local M = {}
+
+---@param entry { name: string, value: string, display: function, index: integer, ordinal: string }
+function M.make_display(entry)
+  Log.debug(
+    ('(%s.make_display): Creating display. Entry values: %s'):format(MODSTR, vim.inspect(entry))
+  )
+  return Entry_display.create({
+    separator = ' ',
+    items = { { width = 30 }, { remaining = true } },
+  })({ entry.name, { entry.value, 'Comment' } })
+end
 
 function M.create_finder()
   local sort = require('project.config').options.telescope.sort
@@ -42,16 +42,21 @@ function M.create_finder()
   Log.debug(('(%s.create_finder): Returning new Finder table.'):format(MODSTR))
   return Finders.new_table({
     results = results,
-    entry_maker = function(entry) ---@param entry string
-      local name = ('%s/%s'):format(
-        vim.fn.fnamemodify(entry, ':h:t'),
-        vim.fn.fnamemodify(entry, ':t')
-      )
+    entry_maker = function(entry) ---@param entry string|ProjectHistoryEntry
+      local History = require('project.util.history')
+      local name ---@type string
+      if History.legacy then
+        ---@cast entry string
+        name = ('%s/%s'):format(vim.fn.fnamemodify(entry, ':h:t'), vim.fn.fnamemodify(entry, ':t'))
+      else
+        ---@cast entry ProjectHistoryEntry
+        name = entry.name
+      end
       return {
         display = M.make_display,
         name = name,
-        value = entry,
-        ordinal = ('%s %s'):format(name, entry),
+        value = History.legacy and entry or entry.path,
+        ordinal = ('%s %s'):format(name, History.legacy and entry or entry.path),
       }
     end,
   })


### PR DESCRIPTION
<!--
PLEASE MAKE SURE YOU READ THE `CONTRIBUTING.md` FILE.
-->

## Checks

- [X] I have read the `CONTRIBUTING.md` file
- [x] I have tested my changes (if applicable)

## Description

The project history used to be just a list of strings, each of one being the path to the project. I've reworked the plugin to store project entries with as a `{ name = 'foo', path = '/path/to/foo' }` table.

The migration still works with the old storage spec, keep that in mind. Migration can be accomplished by running `:ProjectHistory migrate` in your cmdline.

The implementation is currently incomplete, but the hardest part has been worked on!

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
