### PR TITLE
fix: initialize new historyfile with empty array

### DIFF
--- a/lua/project/util/path.lua
+++ b/lua/project/util/path.lua
@@ -275,7 +275,7 @@ function M.init(save_dir, save_file)
       error('(%s.init): Unable to create history file!', ERROR)
     end
 
-    uv.fs_write(fd, '')
+    uv.fs_write(fd, '[]')
     uv.fs_close(fd)
   end
 end


### PR DESCRIPTION
## Checks

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested my changes (if applicable)

## Description

If the plugin is freshly installed, the new history file created is empty. This causes the following error after startup:
```
(project.util.history.read_history): Could not decode JSON data from history file! (`stat.size = 0`) 
```

When opening a .git repository this one:
```
Error in LspAttach Autocommands for "*":                                                                                                                                                                          
Lua callback: (project.util.history.write_history): Unable to decode JSON data!                                                                                                                                   
stack traceback:                                                                                                                                                                                                  
        [C]: in function 'error'                                                                                                                                                                                  
        .../pack/core/opt/project.nvim/lua/project/util/history.lua:682: in function 'write_history'                                                                                                              
        ...pack/site/pack/core/opt/project.nvim/lua/project/api.lua:477: in function 'on_buf_enter'                                                                                                               
        ...pack/site/pack/core/opt/project.nvim/lua/project/api.lua:223: in function <...pack/site/pack/core/opt/project.nvim/lua/project/api.lua:222>                                                            
        [C]: in function 'nvim_exec_autocmds'                                                                                                                                                                     
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:1152: in function 'on_attach'                                                                                                                              
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:613: in function ''                                                                                                                                        
        vim/_core/editor.lua: in function <vim/_core/editor.lua:0>     
```

This fix simply initializes newly created history files with an empty array

## Changes

- Changed `lua/project/util/path.lua:278` from `v.fs_write(fd, '')` to `uv.fs_write(fd, '[]')`

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
