### PR TITLE
fix(windows): fix additional verify_owner calls not early returning

### DIFF
--- a/lua/project/util/path.lua
+++ b/lua/project/util/path.lua
@@ -76,8 +76,8 @@ function M.verify_owner(dir)
   if Util.is_windows() then
     if vim.g.project_verify_windows_logged ~= 1 then
       Log.info(('(%s.verify_owner): Running on a Windows system. Aborting.'):format(MODSTR))
+      vim.g.project_verify_windows_logged = 1
     end
-    vim.g.project_verify_windows_logged = 1
     return true
   end
 

--- a/lua/project/util/path.lua
+++ b/lua/project/util/path.lua
@@ -73,8 +73,10 @@ function M.verify_owner(dir)
   Util.validate({ dir = { dir, { 'string' } } })
 
   local Log = require('project.util.log')
-  if Util.is_windows() and vim.g.project_verify_windows_logged ~= 1 then
-    Log.info(('(%s.verify_owner): Running on a Windows system. Aborting.'):format(MODSTR))
+  if Util.is_windows() then
+    if vim.g.project_verify_windows_logged ~= 1 then
+      Log.info(('(%s.verify_owner): Running on a Windows system. Aborting.'):format(MODSTR))
+    end
     vim.g.project_verify_windows_logged = 1
     return true
   end


### PR DESCRIPTION
<!--
PLEASE MAKE SURE YOU READ THE `CONTRIBUTING.md` FILE.
-->

<!--
## Related Issues

- #1
- #2
--->

## Checks

- [x] I have read the `CONTRIBUTING.md` file
- [x] I have tested my changes (if applicable)

## Description

Commit be46cee9e300d664f80096d288d51019e308dc10 introduced a regression for windows in `util/path.lua`, where subsequent `verify_owner` calls would not early return on windows after the inital log message

## Changes

This fix makes sure it still early returns, but only logs once

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
