### PR TITLE
feat!: new `custom_projects` option (closes #66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ You can check some sample videos in [`EXAMPLES.md`](https://github.com/DrKJeff16
 ## Features
 
 - Automatically sets the `cwd` to the project root directory using pattern matching (LSP optionally)
-- **(NEW)** Projects can be assigned a name (`:ProjectHistory rename [...]`)
+- Projects can be assigned a name (`:ProjectHistory rename [...]`)
+- **(NEW)** Users can define custom project roots, see [Custom Projects](#custom-projects)
 - Users can control whether to run this or not by filetype/buftype
 - Functional `checkhealth` hook (`:checkhealth project`)
 - Vim help documentation ([`:h project-nvim`](https://github.com/DrKJeff16/project.nvim/blob/main/doc/project-nvim.txt))
@@ -93,6 +94,7 @@ Requirements:
 - Neovim >= `v0.11`
 - [`fd`](https://github.com/sharkdp/fd) **(REQUIRED FOR SESSION MANAGEMENT)**
 - [`ibhagwan/fzf-lua`](https://github.com/ibhagwan/fzf-lua) **(OPTIONAL, RECOMMENDED)**
+  - [`wsdjeg/picker.nvim`](https://github.com/wsdjeg/picker.nvim) **(OPTIONAL, RECOMMENDED)**
 - [`nvim-telescope/telescope.nvim`](https://github.com/nvim-telescope/telescope.nvim) **(OPTIONAL, RECOMMENDED)**
   - [`nvim-lua/plenary.nvim`](https://github.com/nvim-lua/plenary.nvim)
   - [`nvim-telescope/telescope-file-browser.nvim`](https://github.com/nvim-telescope/telescope-file-browser.nvim)
@@ -111,6 +113,7 @@ if has('nvim-0.11')
 
   " OPTIONAL
   Plug 'nvim-telescope/telescope.nvim' | Plug 'nvim-lua/plenary.nvim'
+  Plug 'wsdjeg/picker.nvim'
   Plug 'ibhagwan/fzf-lua'
 
   lua << EOF
@@ -283,6 +286,7 @@ By default, `setup()` loads with the following options:
     use_pattern_matching = false,
     no_fallback = false, -- WARNING: ENABLE AT YOUR OWN DISCRETION!!!!
   },
+  custom_projects = {}, -- Read the `Custom Projects` section below
   manual_mode = false,
   patterns = {
     '.git',
@@ -392,7 +396,25 @@ By default, `setup()` loads with the following options:
 }
 ```
 
----
+### Custom Projects
+
+You can pre-define custom project roots in your setup. This is particularly useful for directories
+that don't have `.git` or any other patterns in them.
+
+> [!IMPORTANT]
+> The `path` field has to be an absolute path!
+
+For example:
+
+```lua
+local expand = require('project.util').strip_slash -- WRAPPER FOR `vim.fn.fnamemodify()`, EXPANDS PATHS
+require('project').setup({
+  custom_projects = {
+    { path = expand('~/Projects') }, -- The `name` field is optional
+    { path = expand('~/Documents'), name = 'Documents' },
+  },
+})
+```
 
 ### Pattern Matching
 

--- a/doc/project-nvim.txt
+++ b/doc/project-nvim.txt
@@ -100,6 +100,16 @@ Table of Contents                                             *project-nvim.toc*
                                 Default: `nil` ~
 
 
+    • {custom_projects}         (`{ path: string, name?: string }[]`)
+                                List of predefined projects.
+                                Useful for defining projects that
+                                don't have any useful root markers in them
+                                without having to use |ProjectAdd|.
+                                The {name} field is optional
+
+                                Default: `{}` ~
+
+
     • {different_owners}        (|ProjectOpts.DifferentOwners|)
                                 Table of options used for control for
                                 detecting projects not owned

--- a/lua/project/_meta.lua
+++ b/lua/project/_meta.lua
@@ -92,6 +92,9 @@ local project_paths = { ---@diagnostic disable-line:unused-local
 ---@field name string
 ---@field path string
 
+---@class (exact) ProjectConfigHistoryEntry: ProjectHistoryEntry
+---@field name? string
+
 ---@class (exact) Project.HistoryWin
 ---@field bufnr integer
 ---@field tab integer
@@ -399,6 +402,14 @@ local project_paths = { ---@diagnostic disable-line:unused-local
 ---Default: `nil`
 --- ---
 ---@field before_attach? nil|fun(target_dir: string, method: string)
+---A list of project entries, each one having the following fields:
+---
+--- - `path`: The project path (absolute path)
+--- - `name`: The name of the project
+--- ---
+---Default: `{}`
+--- ---
+---@field custom_projects? ProjectConfigHistoryEntry[]
 ---Table of options used for control for detecting projects not owned by the current user.
 --- ---
 ---@field different_owners? ProjectOpts.DifferentOwners
@@ -514,8 +525,9 @@ local project_paths = { ---@diagnostic disable-line:unused-local
 --- ---
 ---@field telescope? ProjectOpts.Telescope
 
----@class (exact) ProjectDefaults: ProjectOpts
+---@class (exact) ProjectConfigDefaults: ProjectOpts
 ---@field before_attach nil|fun(target_dir: string, method: string)
+---@field custom_projects ProjectConfigHistoryEntry[]
 ---@field different_owners ProjectDefaults.DifferentOwners
 ---@field disable_on ProjectDefaults.DisableOn
 ---@field enable_autochdir boolean
@@ -535,6 +547,8 @@ local project_paths = { ---@diagnostic disable-line:unused-local
 ---@field silent_chdir boolean
 ---@field snacks ProjectDefaults.Snacks
 ---@field telescope ProjectDefaults.Telescope
+
+---@class (exact) ProjectDefaults: ProjectConfigDefaults
 ---@field __index ProjectDefaults
 local D = {}
 

--- a/lua/project/config.lua
+++ b/lua/project/config.lua
@@ -15,9 +15,10 @@ end
 ---@class Project.Config
 ---@field custom_projects ProjectConfigHistoryEntry[]
 ---@field float? Project.ConfigLoc
+---@field options ProjectDefaults
 local M = {}
 
-M.options = setmetatable({}, { __index = get_defaults() }) ---@type ProjectDefaults
+M.config = get_defaults():new()
 
 ---The function called when running `require('project').setup()`.
 --- ---

--- a/lua/project/config.lua
+++ b/lua/project/config.lua
@@ -13,6 +13,7 @@ local function get_defaults()
 end
 
 ---@class Project.Config
+---@field custom_projects ProjectConfigHistoryEntry[]
 ---@field float? Project.ConfigLoc
 local M = {}
 
@@ -67,6 +68,8 @@ function M.setup(options)
     Log.debug(('(%s.setup): snacks.nvim integration enabled.'):format(MODSTR))
     require('project.extensions.snacks').setup(M.options.snacks.opts or {})
   end
+
+  M.custom_projects = vim.deepcopy(M.options.custom_projects or {})
 end
 
 ---@return string config

--- a/lua/project/config/defaults.lua
+++ b/lua/project/config/defaults.lua
@@ -5,8 +5,8 @@ local WARN = vim.log.levels.WARN
 local ERROR = vim.log.levels.ERROR
 local Util = require('project.util')
 
----@diagnostic disable-next-line:missing-fields
-local DEFAULTS = { ---@type ProjectDefaults
+local DEFAULTS = { ---@type ProjectConfigDefaults
+  custom_projects = {},
   different_owners = { allow = false, notify = true },
   picker = { enabled = false, sort = 'newest', hidden = false, show = 'paths' },
   snacks = {
@@ -101,14 +101,17 @@ local DEFAULTS = { ---@type ProjectDefaults
   },
 }
 
-DEFAULTS.__index = DEFAULTS
+---@diagnostic disable-next-line:missing-fields
+local D = {} ---@type ProjectDefaults
+
+D.__index = D
 
 ---Checks the `historysize` option.
 ---
 ---If the option is not valid, a warning will be raised and
 ---the value will revert back to the default.
 --- ---
-function DEFAULTS:verify_history()
+function D:verify_history()
   Util.validate({ history = { self.history, { 'table', 'nil' }, true } })
   self.history = self.history or {}
 
@@ -146,7 +149,7 @@ end
 ---If the option is not valid, a warning will be raised and
 ---the value will revert back to the default.
 --- ---
-function DEFAULTS:verify_scope_chdir()
+function D:verify_scope_chdir()
   Util.validate({ scope_chdir = { self.scope_chdir, { 'string', 'nil' }, true } })
 
   if self.scope_chdir and vim.list_contains({ 'global', 'tab', 'win' }, self.scope_chdir) then
@@ -157,7 +160,7 @@ function DEFAULTS:verify_scope_chdir()
   self.scope_chdir = DEFAULTS.scope_chdir
 end
 
-function DEFAULTS:verify_datapath()
+function D:verify_datapath()
   Util.validate({ history = { self.history, { 'table', 'nil' }, true } })
   self.history = self.history or {}
 
@@ -177,7 +180,7 @@ end
 
 ---@return { [1]: 'pattern' }|{ [1]: 'lsp', [2]: 'pattern' } methods
 ---@nodiscard
-function DEFAULTS:gen_methods()
+function D:gen_methods()
   self:verify_lsp()
   local methods = { 'pattern' } ---@type { [1]: 'pattern' }|{ [1]: 'lsp', [2]: 'pattern' }
   if self.lsp.enabled then
@@ -192,7 +195,7 @@ function DEFAULTS:gen_methods()
   })
 end
 
-function DEFAULTS:verify_logging()
+function D:verify_logging()
   local Path = require('project.util.path')
   local log = self.log
   if not log or type(log) ~= 'table' then
@@ -214,7 +217,7 @@ function DEFAULTS:verify_logging()
   ---@diagnostic enable:need-check-nil
 end
 
-function DEFAULTS:expand_excluded()
+function D:expand_excluded()
   if not self.exclude_dirs or type(self.exclude_dirs) ~= 'table' then
     self.exclude_dirs = {}
   end
@@ -227,7 +230,7 @@ function DEFAULTS:expand_excluded()
   end
 end
 
-function DEFAULTS:verify_lsp()
+function D:verify_lsp()
   self.lsp = self.lsp and vim.tbl_deep_extend('keep', self.lsp, DEFAULTS.lsp) or DEFAULTS.lsp
   if self.use_lsp ~= nil then
     vim.notify('`use_lsp` is deprecated! Use `lsp.enabled` instead.', WARN)
@@ -246,7 +249,7 @@ function DEFAULTS:verify_lsp()
   end
 end
 
-function DEFAULTS:verify_owners()
+function D:verify_owners()
   self.different_owners = self.different_owners or {}
   if self.allow_different_owners ~= nil and type(self.allow_different_owners) == 'boolean' then
     vim.notify('`allow_different_owners` is deprecated! Use `different_owners.allow` instead.', WARN)
@@ -261,7 +264,7 @@ function DEFAULTS:verify_owners()
   end
 end
 
-function DEFAULTS:verify_lists()
+function D:verify_lists()
   local i, found = 1, {} ---@type integer, string[]
   while i <= #self.patterns and i > 0 do
     if
@@ -311,7 +314,7 @@ function DEFAULTS:verify_lists()
   end
 end
 
-function DEFAULTS:verify_fzf_lua()
+function D:verify_fzf_lua()
   Util.validate({ fzf_lua = { self.fzf_lua, { 'table', 'nil' }, true } })
   self.fzf_lua = self.fzf_lua or {}
 
@@ -336,9 +339,10 @@ end
 
 ---Verify config integrity.
 --- ---
-function DEFAULTS:verify()
+function D:verify()
   Util.validate({
     before_attach = { self.before_attach, { 'function', 'nil' }, true },
+    custom_projects = { self.custom_projects, { 'table', 'nil' }, true },
     different_owners = { self.different_owners, { 'table', 'nil' }, true },
     disable_on = { self.disable_on, { 'table', 'nil' }, true },
     enable_autochdir = { self.enable_autochdir, { 'boolean', 'nil' }, true },
@@ -379,16 +383,39 @@ function DEFAULTS:verify()
     end
   end
 
+  if self.custom_projects and not vim.tbl_isempty(self.custom_projects) then
+    if not vim.islist(self.custom_projects) then
+      error(('`custom_projects` is not list-like:\n`%s`'):format(vim.inspect(self.custom_projects)), ERROR)
+    end
+
+    local custom_projects = {} ---@type ProjectConfigHistoryEntry[]
+    for k, v in ipairs(self.custom_projects) do
+      Util.validate({
+        [('custom_projects[%d].path'):format(k)] = { v.path, { 'string' } },
+        [('custom_projects[%d].name'):format(k)] = { v.name, { 'string', 'nil' }, true },
+      })
+
+      if Util.path_exists(Util.strip_slash(v.path)) then
+        table.insert(custom_projects, {
+          path = Util.strip_slash(v.path),
+          name = v.name or (Util.strip_slash(v.path, ':p:h:h:t') .. '/' .. Util.strip_slash(v.path, ':p:h:t')),
+        })
+      end
+    end
+
+    self.custom_projects = vim.deepcopy(custom_projects)
+  end
+
   if self.detection_methods then ---@diagnostic disable-line:undefined-field
     vim.notify('(project.nvim): `detection_methods` has been deprecated!\nUse `lsp.enabled` instead.', WARN)
   end
 end
 
-function DEFAULTS:new(opts)
+function D:new(opts)
   Util.validate({ opts = { opts, { 'table', 'nil' }, true } })
 
-  return setmetatable(opts or {}, DEFAULTS)
+  return setmetatable(vim.tbl_deep_extend('keep', opts or {}, DEFAULTS), D)
 end
 
-return DEFAULTS
+return D
 -- vim: set ts=2 sts=2 sw=2 et ai si sta:

--- a/lua/project/core.lua
+++ b/lua/project/core.lua
@@ -9,10 +9,10 @@ local ERROR = vim.log.levels.ERROR
 local INFO = vim.log.levels.INFO
 local uv = vim.uv or vim.loop
 local Config = require('project.config')
-local Path = require('project.util.path')
-local Util = require('project.util')
 local History = require('project.util.history')
 local Log = require('project.util.log')
+local Path = require('project.util.path')
+local Util = require('project.util')
 
 ---The `project.nvim` API module.
 --- ---
@@ -217,6 +217,13 @@ function M.set_pwd(dir, method)
 
   History.session_projects = History.session_projects or {}
 
+  local custom_name = nil ---@type string|nil
+  for _, v in ipairs(Config.custom_projects) do
+    if Util.strip_slash(v.path) == dir then
+      custom_name = v.name
+    end
+  end
+
   local unexpand_dir, modified = Util.strip_slash(dir, ':p:~'), false
   if
     not vim.tbl_contains(History.session_projects, function(val)
@@ -225,8 +232,9 @@ function M.set_pwd(dir, method)
   then
     table.insert(History.session_projects, History.legacy and dir or {
       path = dir,
-      name = History.find_entry('recent', dir, 'name')
-        or Util.strip_slash(dir, ':p:h:h:t') .. '/' .. Util.strip_slash(dir, ':p:h:t'),
+      name = custom_name
+        or History.find_entry('recent', dir, 'name')
+        or (Util.strip_slash(dir, ':p:h:h:t') .. '/' .. Util.strip_slash(dir, ':p:h:t')),
     })
     modified = true
     Log.info(
@@ -380,7 +388,6 @@ end
 function M.get_current_project(bufnr)
   Util.validate({ bufnr = { bufnr, { 'number', 'nil' }, true } })
   bufnr = (bufnr and Util.is_int(bufnr, bufnr >= 0)) and bufnr or vim.api.nvim_get_current_buf()
-
   if not Util.buffer_valid(bufnr) then
     return
   end

--- a/lua/project/util/history.lua
+++ b/lua/project/util/history.lua
@@ -488,7 +488,11 @@ function M.deserialize_history(history_data, name_data)
       else
         entry = { path = s, name = name_data[i] } --[[@as ProjectHistoryEntry]]
       end
-      if (Config.options.remove_missing_dirs and Path.exists(s)) or not Config.options.remove_missing_dirs then
+      if
+        Config.options
+        and Config.options
+        and ((Config.options.remove_missing_dirs and Path.exists(s)) or not Config.options.remove_missing_dirs)
+      then
         table.insert(projects, entry)
       end
     end
@@ -641,7 +645,11 @@ function M.write_history(path)
     end
   end
 
-  local historysize = require('project.config').options.history.size or 100
+  local Config = require('project.config')
+  local historysize = 100
+  if Config.options and Config.options.history and Config.options.history.size then
+    historysize = Config.options.history.size
+  end
   M.historysize = historysize > 0 and historysize or 100
 
   local file_history = {} ---@type string[]|ProjectHistoryEntry[]

--- a/lua/project/util/path.lua
+++ b/lua/project/util/path.lua
@@ -246,6 +246,11 @@ function M.root_included(dir)
       if pattern:sub(1, 1) == '!' then
         excluded, pattern = true, pattern:sub(2)
       end
+      for _, custom in ipairs(Config.custom_projects) do
+        if dir == custom.path then
+          return dir, 'custom'
+        end
+      end
       if M.match(dir, pattern) then
         if not excluded then
           return dir, ('pattern %s'):format(pattern)


### PR DESCRIPTION
<!--
PLEASE MAKE SURE YOU READ THE `CONTRIBUTING.md` FILE.
-->

## Related Issues

- #66

## Checks

- [X] I have read the `CONTRIBUTING.md` file
- [X] I have tested my changes (if applicable)

## Description

Now `project.nvim` allows the user to set their custom projects without the need to rely on `.git` or other custom patterns.

```lua
-- EXAMPLE
require('project').setup({
  custom_projects = {
    { path = vim.fn.expand('~/Projects') }, -- `name` is optional
    { path = vim.fn.expand('~/Documents'), name = 'Documents' },
  },
})
```

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
