### PR TITLE
refactor(commands)!: merge all user commands into `:Project`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ You can check some sample videos in [`EXAMPLES.md`](https://github.com/DrKJeff16
 ## Features
 
 - Automatically sets the `cwd` to the project root directory using pattern matching (LSP optionally)
-- Projects can be assigned a name (`:ProjectHistory rename [...]`)
+- Projects can be assigned a name (`:Project history rename [...]`)
 - **(NEW)** Users can define custom project roots, see [Custom Projects](#custom-projects)
 - Users can control whether to run this or not by filetype/buftype
 - Functional `checkhealth` hook (`:checkhealth project`)
 - Vim help documentation ([`:h project-nvim`](https://github.com/DrKJeff16/project.nvim/blob/main/doc/project-nvim.txt))
-- Logging capabilities ([`:ProjectLog`](#projectlog))
+- Logging capabilities
 - Natively supports `.nvim.lua` files
 - `vim.ui` menu support
 - [`oil.nvim`](https://github.com/stevearc/oil.nvim) support
@@ -59,22 +59,8 @@ You can check some sample videos in [`EXAMPLES.md`](https://github.com/DrKJeff16
   - [`mini.starter`](#ministarter)
   - [`picker.nvim`](#pickernvim)
   - [`snacks.nvim`](#snacksnvim)
-- [Commands](#commands)
-  - [`:Project`](#project)
-  - [`:ProjectAdd`](#projectadd)
-  - [`:ProjectConfig`](#projectconfig)
-  - [`:ProjectDelete`](#projectdelete)
-  - [`:ProjectExport`](#projectexport)
-  - [`:ProjectFzf`](#projectfzf)
-  - [`:ProjectHealth`](#projecthealth)
-  - [`:ProjectHistory`](#projecthistory)
-  - [`:ProjectImport`](#projectimport)
-  - [`:ProjectLog`](#projectlog)
-  - [`:ProjectPicker`](#projectpicker)
-  - [`:ProjectRecents`](#projectrecents)
-  - [`:ProjectRoot`](#projectroot)
-  - [`:ProjectSession`](#projectsession)
-  - [`:ProjectTelescope`](#projecttelescope)
+- [Usage](#usage)
+  - [Extra Operations](#extra-operations)
 - [API](#api)
   - [`get_project_root()`](#get_project_root)
   - [`get_recent_projects()`](#get_recent_projects)
@@ -148,24 +134,7 @@ If you wish to lazy-load this plugin:
 ```lua
 {
   'DrKJeff16/project.nvim',
-  cmd = { -- Lazy-load by commands
-    'Project',
-    'ProjectAdd',
-    'ProjectConfig',
-    'ProjectDelete',
-    'ProjectExport',
-    'ProjectFzf', -- If using `fzf-lua` integration
-    'ProjectHealth',
-    'ProjectHistory',
-    'ProjectImport',
-    'ProjectLog', -- If logging is enabled
-    'ProjectPicker', -- If using `picker.nvim` integration
-    'ProjectRecents',
-    'ProjectRoot',
-    'ProjectSession',
-    'ProjectSnacks', -- If using `snacks.nvim` integration
-    'ProjectTelescope', -- If using `telescope.nvim` integration
-  },
+  cmd = { 'Project' }, -- Lazy-load by commands
   dependencies = { -- OPTIONAL. Choose any of the following
     { 'nvim-telescope/telescope.nvim', dependencies = { 'nvim-lua/plenary.nvim' } },
     'wsdjeg/picker.nvim',
@@ -606,7 +575,7 @@ require('mini.starter').setup({
   evaluate_single = true,
   items = {
     { name = 'Projects', action = 'Project', section = 'Projects' }, -- Runs `:Project`
-    { name = 'Recent Projects', action = 'ProjectRecents', section = 'Projects' }, -- `:ProjectRecents`
+    { name = 'Recent Projects', action = 'ProjectRecents', section = 'Projects' }, -- `:Project recents`
     -- Other items...
   },
 })
@@ -614,9 +583,8 @@ require('mini.starter').setup({
 
 ### `picker.nvim`
 
-This plugin has a custom integration with [@wsdjeg](https://github.com/wsdjeg)'s
-[`picker.nvim`](https://github.com/wsdjeg/picker.nvim).
-If enabled, the [`:ProjectPicker`](#projectpicker) command will be available to you.
+This plugin has a custom integration with [@wsdjeg](https://github.com/wsdjeg)'s [`picker.nvim`](https://github.com/wsdjeg/picker.nvim).
+If enabled, the `:Project picker` command will be available to you.
 
 To enable it you'll need the plugin installed, then in your setup:
 
@@ -645,7 +613,7 @@ You can find the integration in:
 ### `snacks.nvim`
 
 This plugin has a custom integration with [`snacks.nvim`](https://github.com/folke/snacks.nvim).
-If enabled, the [`:ProjectSnacks`](#projectsnacks) command will be available to you.
+If enabled, the `:Project snacks` command will be available to you.
 
 ```lua
 require('project.extensions.snacks').pick()
@@ -656,7 +624,7 @@ To enable and configure it you'll need the plugin installed, then in your setup:
 ```lua
 require('project').setup({
   snacks = {
-    enabled = true, -- Will enable the `:ProjectSnacks` command
+    enabled = true, -- Will enable the `:Project snacks` command
     opts = {
       sort = 'newest',
       hidden = false,
@@ -680,249 +648,193 @@ You can find the integration in [_`extensions/snacks.lua`_](https://github.com/D
 
 ---
 
-## Commands
+## Usage
 
-These are the user commands you can call from the cmdline:
+You may use the `:Project` user command in your cmdline to manage your experience.
 
-### `:Project`
-
-The `:Project` command will open a UI window pointing to all the useful operations
-this plugin can provide. This one is subject to change, just as `vim.ui` is.
+Without any arguments being passed, a UI selection window with all the important operations will be opened.
 
 See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
 
-### `:ProjectAdd`
+### Extra Operations
 
-The `:ProjectAdd` command is a manual hook that opens a prompt to input any
-directory through a UI prompt, to be saved to your project history.
+You also have the following subcommands:
 
-If your prompt is valid, your `cwd` will be switched to said directory.
-Adding a [!] will set the prompt to your cwd.
+-  `:Project[!] add [/path/to/project [/path/to/project [...]]]`:
 
-**This is particularly useful if you've enabled `manual_mode` in `setup()`.**
+If no other args are passed, you'll be prompted to input any directory to be saved
+to your project history (adding a `!` will set the prompt to your cwd).
 
-See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
+If one or more args are passed, you will not be prompted (the arguments must be valid paths).
 
-### `:ProjectConfig`
+-  `:Project[!] config`:
 
-The `:ProjectConfig` command will toggle your current config in a floating window,
-making it easier to access. To exit the window you can either press `q` in normal mode
-or by runnning `:ProjectConfig` again.
+Will toggle a floating window with your current config.
+To exit the window you can either press `q` in normal mode or by runnning `:Project config` again.
 
-You can also print the output instead by running `:ProjectConfig!`.
+You can also print the output instead by running `:Project! config`.
 
-See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
-
-### `:ProjectDelete`
-
-The `:ProjectDelete` command is a utility to delete your projects.
+- `:Project[!] delete [/path/to/project [...]]`:
 
 If no arguments are given, a popup with a list of your current projects will be opened.
 
-If one or more arguments are passed, it will expect directories separated
-by a space. The arguments have to be directories that are returned by `get_recent_projects()`.
-The arguments can be relative, absolute or un-expanded (`~/path/to/project`).
-The command will attemptto parse the args and, unless a `!` is passed to the command
-(`:ProjectDelete!`). In that case, invalid args will be ignored.
+If one or more arguments are passed, it will expect directories separated by a space.
+The arguments have to be directories that are returned by `Core.get_recent_projects()`
+and can be relative, absolute or un-expanded (`~/path/to/project`).
+
+The command will attemptto parse the args and, unless a `!` is passed (`:Project! delete`).
+In that case, invalid args will be ignored.
 
 If there's a successful deletion, you'll recieve a notification denoting success.
 
-Usage:
-
-```vim
-" Vim command line
-:ProjectDelete[!] [/path/to/first [/path/to/second [...]]]
-```
-
-For more info, see:
-
-- _`:h :ProjectDelete`_
-- [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua)
-
-### `:ProjectExport`
+- `:Project[!] export [/path/to/file[.json] [<INT>]\]`
 
 > [!WARNING]
-> **_Use this script with caution, as you may overwrite your files if doing something reckless!_**
+> **_Use this subcommand with caution, as you may overwrite your files if doing something reckless!_**
 
-The `:ProjectExport` allows the user to save their project history in a JSON format,
-allowing a custom indent level if desired.
-
-If the target file already exists and is not empty then a confirmation prompt
-will appear.
+Allows you to save your project history in a portable JSON format, and with a custom indent level if desired.
+If the target file already exists and is not empty then a confirmation prompt will appear.
 
 Example usage:
 
 ```vim
-" Will open a prompt
-:ProjectExport
-
-" The output file will be `a.json`
-:ProjectExport a
-
-" The output file will be `b`, with a tab size of 12
-:ProjectExport! b 12
-
-" The output file will be `~/.c.json` (bang here is irrelevant)
-:ProjectExport! ~/.c.json
+:Project export " Will open a prompt
+:Project export a " The output file will be `a.json`
+:Project! export b 12 " The output file will be `b`, with a tab size of 12
 ```
 
-### `:ProjectFzf`
+- `:Project fzf-lua`
 
 > [!IMPORTANT]
 > **This command works ONLY if you have `fzf-lua` installed and loaded
 > and `fzf_lua.enabled` set to `true`.**
 
-The `:ProjectFzf` command is a dynamically enabled user command that opens a `fzf-lua` picker
-for `project.nvim`.
-For now it just executes `require('project').run_fzf_lua()`.
+If the `fzf-lua` integration is enabled in your setup, it will open a `fzf-lua` picker for `project.nvim`.
 
 Mappings:
 
-| Mapping | Description                 |
-|---------|-----------------------------|
-| `<C-d>` | Delete the selected project |
+| Mapping | Description                  |
+|---------|------------------------------|
+| `<C-d>` | Delete the selected project  |
+| `<C-r>` | Renames the selected project |
 
 See [_`extensions/fzf-lua.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/extensions/fzf-lua.lua)
 for more info.
 
-### `:ProjectHealth`
+- `:Project health`
 
-The `:ProjectHealth` command runs `:checkhealth project` in a single command.
+Simply runs `:checkhealth project`.
 
-See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
+- `:Project[!] history [clear|rename [/path/to/project [/path/to/project] [...]\]\]`
 
-### `:ProjectHistory`
-
-The `:ProjectHistory` handles the project history.
-
-If the command is called without any arguments it'll toggle the `project.nvim` history file
+If the command is called without any extra arguments it'll toggle the `project.nvim` history file
 in a new tab, which can be exited by pressing `q` in Normal Mode.
 
-If you need to migrate your project history to the new spec, simply run `:ProjectHistory migrate`
-once and that's it! After migration this command will not be available unless another migration is
+If you need to migrate your project history to the new spec, simply run `:Project history migrate`
+once and that's it! After migration this subcommand will not be available unless another migration is
 needed.
 
-If you wish to rename a project (MIGRATION REQUIRED) you can call `:ProjectHistory rename`,
-with or without arguments passed to it.
+**(MIGRATION REQUIRED)**
+If you wish to rename a project you can call `:Project history rename`, with or without
+any arguments passed to it.
 If no arguments are passed, a custom UI list will open, showing you your projects to be renamed.
 If one or more arguments are passed, these must be the paths to your projects (absolute or relative).
 
 **(DANGER ZONE)**
-If called with the `clear` argument (`:ProjectHistory[!] clear`) your project history
-will be cleared. If you want to avoid a "Yes/No" prompt you can call the command
-with a bang (`!`) to force it.
+If called with the `clear` argument (`:Project[!] history clear`) your project history will be cleared.
+If you want to avoid a "Yes/No" prompt you can call the command with a bang (`!`) to force it.
 
 Usage:
 
 ```vim
-:ProjectHistory
-:ProjectHistory[!] clear
-:ProjectHistory migrate                         " Will migrate your history to the newest spec
-:ProjectHistory rename [/path/to/project [...]] " (NEEDS MIGRATION) Will rename the specified projects
+:Project history
+:Project[!] history clear
+:Project history migrate                         " Will migrate your history to the newest spec
+:Project history rename [/path/to/project [...]] " (NEEDS MIGRATION) Will rename the specified projects
 ```
 
-See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
+- `:Project[!] import [/path/to/file[.json]\]`
 
-### `:ProjectImport`
-
-The `:ProjectImport` allows the user to retrieved their saved project history in a JSON format.
+Allows you to retrieve any previously exported project history (through `:Project export`).
 
 Example usage:
 
 ```vim
-" Will open a prompt
-:ProjectImport
+:Project import " Will open a prompt
 
-" Will be treated as `a.json`
-:ProjectExport a
-:ProjectImport a
+:Project export a " Will be treated as `a.json`
+:Project import a " Will be treated as `a.json`
 
-" Will be treated as `b`
-:ProjectExport! b
-:ProjectImport! b
+:Project! export b " Will be treated as `b`
+:Project! import b " Will be treated as `b`
 ```
 
-### `:ProjectLog`
+- `:Project log [clear|close|open|toggle]`
 
 > [!IMPORTANT]
-> This command will not be available unless you set `log.enabled = true`
-> in your `setup()`.
+> This command will not be available unless you set `log.enabled = true` in your setup.
 
-The `:ProjectLog` command handles the `project.nvim` log file.
-
-The valid arguments are:
+Handles the `project.nvim` log file. The valid arguments are:
 
 ```vim
-:ProjectLog           " Toggles the window
-:ProjectLog clear     " Clears the current log file. Will close any opened log window
-:ProjectLog close     " Closes the Log Window
-:ProjectLog open      " Opens the Log Window
-:ProjectLog toggle    " Toggles the Log Window
+:Project log           " Toggles the window
+:Project log clear     " Clears the current log file. Will close any opened log window
+:Project log close     " Closes the Log Window
+:Project log open      " Opens the Log Window
+:Project log toggle    " Toggles the Log Window
 ```
 
-See [_`log.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/util/log.lua) for more info.
-
-### `:ProjectPicker`
+- `:Project[!] picker`
 
 > [!IMPORTANT]
-> **This command works ONLY if you have `picker.nvim` installed
-> and `picker.enabled` set to `true`.**
+> **This command works ONLY if you have `picker.nvim` installed and `picker.enabled` set to `true`.**
 
-The `:ProjectPicker` command is a dynamically enabled user command that runs
-`project.nvim` through `picker.nvim`.
+Runs `project.nvim` through `picker.nvim`.
 
-If a bang is passed (`:ProjectPicker!`) and you don't already have `picker.hidden` set to `true`,
+If a bang is passed (`:Project! picker`) and you don't already have `picker.hidden` set to `true`,
 then a selected project will show hidden files.
 
-This is an alias for `:Picker project`.
+- `:Project recents`
 
-See [_`picker.nvim` Integration_](#pickernvim) for more info.
+Will open a UI window showing you the list of your recently used projects.
 
-### `:ProjectRecents`
+- `:Project[!] root`
 
-The `:ProjectRecents` command will open a UI window showing you the list of your recently used
-projects.
+> [!NOTE]
+> Useful if you have set `manual_mode` to `true` in your setup.
 
-See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
+A manual hook to set the working directory to the current file's root, using the available
+detection methods set by the user.
 
-### `:ProjectRoot`
+If a bang is passed (`:Project! root`) and your cwd is already in the project history, then
+the command will not fail and will execute as if your cwd is not in the history already.
 
-The `:ProjectRoot` command is a manual hook to set the working directory to the current
-file's root, attempting to use any of the `setup()` detection methods
-set by the user.
-
-The command is like doing the following in the cmdline:
+If successful, the command will execute the following code:
 
 ```vim
 :lua require('project.core').on_buf_enter()
 ```
 
-See [_`commands.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/commands.lua) for more info.
-
-### `:ProjectSession`
+- `:Project[!] session`
 
 > [!IMPORTANT]
 > **This command requires `fd` to be installed for it to work!**
 
-The `:ProjectSession` command opens a custom picker with a selection of
-your current session projects (stored in `History.session_projects`). **Bear in mind this table gets
-filled on runtime**.
+Will open a custom picker with a selection of your current session projects (stored in `History.session_projects`).
 
 If you select a session project, your `cwd` will be changed to what you selected.
-If the command is called with a `!` (`:ProjectSession!`) the UI will close.
-Otherwise, another custom UI picker will appear for you to select the files/dirs.
-Selecting a directory will open another UI picker with its contents, and so on.
 
-See [_`popup.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/project/popup.lua) for more info.
+If a bang is passed (`:Project! session`), then the UI will close if it's open. Otherwise,
+another custom UI picker will appear for you to select the files/dirs.
 
-### `:ProjectSnacks`
+Selecting a directory will open another UI picker with the project's contents, and so on.
+
+### `:Project snacks`
 
 > [!IMPORTANT]
-> **This command works ONLY if you have `snacks.nvim` installed
-> and `snacks.enabled` set to `true`.**
+> **This command works ONLY if you have `snacks.nvim` installed and `snacks.enabled` set to `true`.**
 
-The `:ProjectSnacks` command is a dynamically enabled user command that runs
-`project.nvim` through `snacks.nvim`.
+A dynamically enabled user command that runs `project.nvim` through `snacks.nvim`.
 
 This is an alias for:
 
@@ -930,19 +842,13 @@ This is an alias for:
 require('project.extensions.snacks').pick()
 ```
 
-See [_`snacks.nvim` Integration_](#snacksnvim) for more info.
-
-### `:ProjectTelescope`
+- `:Project telescope`
 
 > [!IMPORTANT]
 > **This command works ONLY if you have `telescope.nvim` installed and loaded**
 
-The `:ProjectTelescope` command is a dynamicly enabled User Command that runs
-the Telescope `projects` picker.
-A shortcut, to be honest.
-
-See [_`telescope/_extensions/projects.lua`_](https://github.com/DrKJeff16/project.nvim/blob/main/lua/telescope/_extensions/projects.lua)
-for more info.
+A dynamicly enabled user command that runs the Telescope `projects` picker.
+This is a shortcut for `:Telescope projects`.
 
 ---
 

--- a/lua/project/commands.lua
+++ b/lua/project/commands.lua
@@ -112,114 +112,281 @@ function M.create_user_commands()
         if args[1]:sub(-1) == '!' and #args == 1 then
           return {}
         end
+
+        local items = { ---@type string[]
+          'add',
+          'config',
+          'delete',
+          'export',
+          'health',
+          'history',
+          'import',
+          'recents',
+          'root',
+          'session',
+        }
+        if vim.g.project_fzf_lua_loaded == 1 then
+          table.insert(items, 'fzf-lua')
+        end
+        if vim.g.project_log_loaded == 1 then
+          table.insert(items, 'log')
+        end
+        if vim.g.project_picker_loaded == 1 then
+          table.insert(items, 'picker')
+        end
+        if vim.g.project_telescope_loaded == 1 then
+          table.insert(items, 'telescope')
+        end
+        if vim.g.project_snacks_loaded == 1 then
+          table.insert(items, 'snacks')
+        end
+        table.sort(items)
+
         if #args == 2 then
           if args[2] == '' then
-            local res = Popup.open_menu.choices_list(false)
-            for i, v in ipairs(res) do
-              if v == 'Exit' then
-                table.remove(res, i)
-                break
-              end
-            end
-            table.sort(res)
-            return res
+            return items
           end
 
-          local res = {}
-          for _, choice in ipairs(Popup.open_menu.choices_list(false)) do
-            if vim.startswith(choice, args[2]) and choice ~= 'Exit' then
-              table.insert(res, choice)
+          local res = {} ---@type string[]
+          for _, item in ipairs(items) do
+            if vim.startswith(item, args[2]) then
+              table.insert(res, item)
             end
           end
           table.sort(res)
           return res
         end
+        if #args >= 3 then
+          if
+            not vim.list_contains(items, args[2])
+            or vim.list_contains({
+              'config',
+              'fzf-lua',
+              'health',
+              'picker',
+              'recents',
+              'root',
+              'session',
+              'snacks',
+              'telescope',
+            }, args[2])
+          then
+            return {}
+          end
+
+          local res = {} ---@type string[]
+          if args[2] == 'log' and #args == 3 then
+            for _, comp in ipairs({ 'clear', 'close', 'open', 'toggle' }) do
+              if vim.startswith(comp, args[3]) then
+                table.insert(res, comp)
+              end
+            end
+            table.sort(res)
+            return res
+          end
+          if args[2] == 'add' then
+            return vim.tbl_map(function(value) ---@param value string
+              return vim.fn.fnamemodify(value, ':p:~')
+            end, vim.fn.getcompletion(args[#args], 'dir', true))
+          end
+          if args[2] == 'delete' or (#args >= 4 and args[2] == 'history' and args[3] == 'rename') then
+            table.remove(args, 1)
+            return complete_items(_, table.concat(args, ' '))
+          end
+          if args[2] == 'history' and #args == 3 then
+            local options = { 'clear' } ---@type string[]
+            table.insert(options, History.legacy and 'migrate' or 'rename')
+
+            for _, choice in ipairs(options) do
+              if vim.startswith(choice, args[3]) then
+                table.insert(res, choice)
+              end
+            end
+            return res
+          end
+          if args[2] == 'export' then
+            if #args == 3 then
+              return vim.fn.getcompletion(args[3], 'file', true)
+            end
+
+            if #args == 4 then
+              ---@type string[]
+              local nums = vim.tbl_map(function(value) ---@param value integer
+                return tostring(value)
+              end, Util.range(0, 32, 2))
+              if args[4] == '' then
+                return nums
+              end
+
+              for _, num in ipairs(nums) do
+                if vim.startswith(num, args[4]) then
+                  table.insert(res, num)
+                end
+              end
+              return res
+            end
+          end
+          if args[2] == 'import' and #args == 3 then
+            return vim.fn.getcompletion(args[3], 'file', true)
+          end
+        end
         return {}
       end,
       callback = function(ctx)
-        Popup.open_menu(ctx)
-      end,
-    },
-    {
-      name = 'ProjectAdd',
-      desc = 'Prompt to add the current directory to the project history',
-      bang = true,
-      nargs = '*',
-      complete = 'file',
-      callback = function(ctx)
-        if ctx and vim.tbl_isempty(ctx.fargs) then
-          ---@type vim.ui.input.Opts
-          local opts = { prompt = 'Input a valid path to the project:', completion = 'dir' }
-          if ctx.bang then
-            local bufnr = vim.api.nvim_get_current_buf()
-            opts.default = Util.strip_slash(vim.api.nvim_buf_get_name(bufnr), ':p:h')
-          end
-
-          vim.ui.input(opts, Popup.prompt_project)
+        if vim.tbl_isempty(ctx.fargs) then
+          Popup.open_menu(ctx)
           return
         end
 
-        local msg = ''
-        for _, input in ipairs(ctx.fargs) do
-          input = Util.strip_slash(input)
-          if Util.dir_exists(input) then
-            if
-              Core.current_project ~= input
-              and not vim.tbl_contains(History.session_projects, function(val) ---@param val string|ProjectHistoryEntry
-                return (History.legacy and val or val.path) == input
-              end, { predicate = true })
-            then
-              Core.set_pwd(input, 'manual')
-              History.write_history()
-            else
-              msg = ('%s%sAlready added `%s`!'):format(msg, msg == '' and '' or '\n', input)
+        local items = { ---@type string[]
+          'add',
+          'config',
+          'delete',
+          'export',
+          'health',
+          'history',
+          'import',
+          'recents',
+          'root',
+          'session',
+        }
+        if vim.g.project_fzf_lua_loaded == 1 then
+          table.insert(items, 'fzf-lua')
+        end
+        if vim.g.project_log_loaded == 1 then
+          table.insert(items, 'log')
+        end
+        if vim.g.project_picker_loaded == 1 then
+          table.insert(items, 'picker')
+        end
+        if vim.g.project_telescope_loaded == 1 then
+          table.insert(items, 'telescope')
+        end
+        if vim.g.project_snacks_loaded == 1 then
+          table.insert(items, 'snacks')
+        end
+        table.sort(items)
+
+        local err = [[  :Project
+  :Project health
+  :Project recents
+  :Project[!] add [/path/to/dir [/path/to/dir [...]\]
+  :Project[!] config
+  :Project[!] delete [/path/to/project [/path/to/project [...]\]
+  :Project[!] export [/path/to/file[.json] [<INT>]\]
+  :Project[!] history [clear|rename [/path/to/project [/path/to/project] [...]\]\]
+  :Project[!] import [/path/to/file[.json]\]
+  :Project[!] root
+  :Project[!] session
+        ]]
+
+        if vim.g.project_log_loaded == 1 then
+          err = ('%s\n  :Project log [clear|close|open|toggle]'):format(err)
+        end
+        if vim.g.project_fzf_lua_loaded == 1 then
+          err = ('%s\n  :Project fzf-lua'):format(err)
+        end
+        if vim.g.project_picker_loaded == 1 then
+          err = ('%s\n  :Project[!] picker'):format(err)
+        end
+        if vim.g.project_snacks_loaded == 1 then
+          err = ('%s\n  :Project snacks'):format(err)
+        end
+        if vim.g.project_telescope_loaded == 1 then
+          err = ('%s\n  :Project telescope'):format(err)
+        end
+
+        local err_tbl = vim.split(err, '\n', { trimempty = true })
+        table.sort(err_tbl)
+        local err_txt = table.concat(err_tbl, '\n')
+
+        local fargs = vim.deepcopy(ctx.fargs)
+        table.remove(fargs, 1)
+
+        if ctx.fargs[1] == 'add' then
+          if vim.tbl_isempty(fargs) then
+            ---@type vim.ui.input.Opts
+            local opts = { prompt = 'Input a valid path to the project:', completion = 'dir' }
+            if ctx.bang then
+              local bufnr = vim.api.nvim_get_current_buf()
+              opts.default = Util.strip_slash(vim.api.nvim_buf_get_name(bufnr), ':p:h')
             end
-          else
-            msg = ('%s%s`%s` is not a directory!'):format(msg, msg == '' and '' or '\n', input)
+
+            vim.ui.input(opts, Popup.prompt_project)
+            return
           end
-        end
 
-        vim.notify(msg, WARN)
-      end,
-    },
-    {
-      name = 'ProjectConfig',
-      desc = 'Prints out the current configuratiion for `project.nvim`',
-      bang = true,
-      callback = function(ctx)
-        if ctx and ctx.bang then
-          vim.print(Config.get_config())
+          local msg = ''
+          for _, input in ipairs(fargs) do
+            input = Util.strip_slash(input)
+            if Util.dir_exists(input) then
+              if
+                Core.current_project ~= input
+                and not vim.tbl_contains(
+                  History.session_projects,
+                  function(val) ---@param val string|ProjectHistoryEntry
+                    return (History.legacy and val or val.path) == input
+                  end,
+                  { predicate = true }
+                )
+              then
+                Core.set_pwd(input, 'manual')
+                History.write_history()
+              else
+                msg = ('%s%sAlready added `%s`!'):format(msg, msg == '' and '' or '\n', input)
+              end
+            else
+              msg = ('%s%s`%s` is not a directory!'):format(msg, msg == '' and '' or '\n', input)
+            end
+          end
+          vim.notify(msg, WARN)
           return
         end
+        if ctx.fargs[1] == 'config' then
+          if ctx.bang then
+            vim.print(Config.get_config(), INFO)
+            return
+          end
 
-        Config.toggle_win()
-      end,
-    },
-    {
-      name = 'ProjectDelete',
-      desc = 'Deletes the projects given as args, assuming they are valid. No args open a popup',
-      bang = true,
-      nargs = '*',
-      complete = complete_items,
-      callback = function(ctx)
-        if not ctx or vim.tbl_isempty(ctx.fargs) then
-          Popup.delete_menu()
+          Config.toggle_win()
           return
         end
+        if ctx.fargs[1] == 'delete' then
+          if vim.tbl_isempty(fargs) then
+            Popup.delete_menu()
+            return
+          end
 
-        local recent = History.get_recent_projects()
-        if not recent then
-          Log.error('(:ProjectDelete): No recent projects!')
-          vim.notify('(:ProjectDelete): No recent projects!', ERROR)
-          return
-        end
+          local recent = History.get_recent_projects()
+          if not recent then
+            Log.error('(:Project delete): No recent projects!')
+            vim.notify('(:Project delete): No recent projects!', ERROR)
+            return
+          end
 
-        for _, v in ipairs(ctx.fargs) do
-          local path = Util.strip_slash(v)
-          if
-            not (
-              ctx.bang
-              or vim.tbl_contains(recent, function(val) ---@param val string|ProjectHistoryEntry
+          for _, v in ipairs(fargs) do
+            local path = Util.strip_slash(v)
+            if
+              not (
+                ctx.bang
+                or vim.tbl_contains(recent, function(val) ---@param val string|ProjectHistoryEntry
+                  Log.debug(
+                    ('`%s` =? `%s` ==> %s'):format(
+                      path,
+                      History.legacy and val or val.path,
+                      vim.inspect((History.legacy and val or val.path) == path)
+                    )
+                  )
+                  return (History.legacy and val or val.path) == path
+                end, { predicate = true })
+              ) or path == ''
+            then
+              Log.error(('(:Project delete): Could not delete `%s`, aborting'):format(path))
+              vim.notify(('(:Project delete): Could not delete `%s`, aborting'):format(path), ERROR)
+              return
+            end
+            if
+              vim.tbl_contains(recent, function(val) ---@param val string|ProjectHistoryEntry
                 Log.debug(
                   ('`%s` =? `%s` ==> %s'):format(
                     path,
@@ -229,235 +396,151 @@ function M.create_user_commands()
                 )
                 return (History.legacy and val or val.path) == path
               end, { predicate = true })
-            ) or path == ''
-          then
-            Log.error(('(:ProjectDelete): Could not delete `%s`, aborting'):format(path))
-            vim.notify(('(:ProjectDelete): Could not delete `%s`, aborting'):format(path), ERROR)
+            then
+              History.delete_project(path)
+            end
+          end
+          return
+        end
+        if ctx.fargs[1] == 'export' and #fargs <= 2 then
+          if vim.tbl_isempty(fargs) then
+            Popup.gen_export_prompt()
             return
           end
-          if
-            vim.tbl_contains(recent, function(val) ---@param val string|ProjectHistoryEntry
-              Log.debug(
-                ('`%s` =? `%s` ==> %s'):format(
-                  path,
-                  History.legacy and val or val.path,
-                  vim.inspect((History.legacy and val or val.path) == path)
-                )
-              )
-              return (History.legacy and val or val.path) == path
-            end, { predicate = true })
-          then
-            History.delete_project(path)
-          end
-        end
-      end,
-    },
-    {
-      name = 'ProjectExport',
-      desc = 'Export project.nvim history to JSON file',
-      bang = true,
-      nargs = '*',
-      complete = function(_, line)
-        local args = vim.split(line, '%s+', { trimempty = false })
-        if args[1]:sub(-1) == '!' and #args == 1 then
-          return {}
-        end
 
-        -- Thanks to @TheLeoP for the advice!
-        -- https://www.reddit.com/r/neovim/comments/1pvl1tb/comment/nvwzvvu/
-        if #args == 2 then
-          local completions = vim.fn.getcompletion(args[2], 'file', true)
-          local items = {} ---@type string[]
-          for _, v in ipairs(completions) do
-            if vim.startswith(v, args[2]) then
-              table.insert(items, v)
-            end
-          end
-
-          return vim.tbl_isempty(items) and completions or items
-        end
-
-        if #args == 3 then
-          ---@type string[]
-          local nums = vim.tbl_map(function(value) ---@param value integer
-            return tostring(value)
-          end, Util.range(0, 32, 2))
-          if args[3] == '' then
-            return nums
-          end
-
-          local res = {} ---@type string[]
-          for _, num in ipairs(nums) do
-            if vim.startswith(num, args[3]) then
-              table.insert(res, num)
-            end
-          end
-          return res
-        end
-
-        return {}
-      end,
-      callback = function(ctx)
-        if not ctx or #ctx.fargs > 2 then
-          vim.notify('Usage:  `:ProjectExport[!] </path/to/file[.json]> [<INDENT>]`', WARN)
+          History.export_history_json(fargs[1], #fargs == 2 and tonumber(fargs[2]) or nil, ctx.bang)
           return
         end
-        if vim.tbl_isempty(ctx.fargs) then
-          Popup.gen_export_prompt()
+        if vim.g.project_fzf_lua_loaded == 1 and ctx.fargs[1] == 'fzf-lua' and vim.tbl_isempty(fargs) then
+          require('project.extensions.fzf-lua').run_fzf_lua()
           return
         end
-
-        History.export_history_json(ctx.fargs[1], #ctx.fargs == 2 and tonumber(ctx.fargs[2]) or nil, ctx.bang)
-      end,
-    },
-    {
-      name = 'ProjectHealth',
-      desc = 'Run checkhealth for project.nvim',
-      callback = function()
-        vim.cmd.checkhealth('project')
-      end,
-    },
-    {
-      name = 'ProjectHistory',
-      desc = 'Manage project history',
-      bang = true,
-      nargs = '*',
-      complete = function(_, line)
-        local args = vim.split(line, '%s+', { trimempty = false })
-        if args[1]:sub(-1) == '!' and #args == 1 then
-          return {}
+        if ctx.fargs[1] == 'health' and vim.tbl_isempty(fargs) then
+          vim.cmd.checkhealth('project')
+          return
         end
-
-        if #args == 2 then
-          local options, res = { 'clear' }, {} ---@type string[], string[]
-          table.insert(options, History.legacy and 'migrate' or 'rename')
-
-          for _, choice in ipairs(options) do
-            if vim.startswith(choice, args[2]) then
-              table.insert(res, choice)
-            end
+        if ctx.fargs[1] == 'history' then
+          if vim.tbl_isempty(fargs) then
+            History.toggle_win()
+            return
           end
-          return res
-        end
-        if #args > 2 and args[2] == 'rename' then
-          return complete_items(_, line)
-        end
-        return {}
-      end,
-      callback = function(ctx)
-        ctx.fargs[1] = ctx.fargs[1] or ''
-        if ctx.fargs[1] == '' then
-          History.toggle_win()
-          return
-        end
 
-        local options = { 'clear', 'migrate' } ---@type string[]
-        if not History.legacy then
-          table.insert(options, 'rename')
-        end
-
-        if not vim.list_contains(options, ctx.fargs[1]) then
-          vim.notify('Usage:  `:ProjectHistory[!] [clear|migrate|rename]`', WARN)
-          return
-        end
-
-        if ctx.fargs[1] == 'clear' then
-          History.clear_historyfile(ctx.bang)
-          return
-        end
-
-        if ctx.fargs[1] == 'migrate' then
+          local options = { 'clear', 'migrate' } ---@type string[]
           if not History.legacy then
-            vim.notify('Your project history has already been migrated!', WARN)
+            table.insert(options, 'rename')
+          end
+
+          if vim.list_contains(options, fargs[1]) then
+            if fargs[1] == 'clear' then
+              History.clear_historyfile(ctx.bang)
+              return
+            end
+
+            if fargs[1] == 'migrate' then
+              if not History.legacy then
+                vim.notify('Your project history has already been migrated!', WARN)
+                return
+              end
+
+              History.migrate()
+              return
+            end
+
+            if #fargs == 1 then
+              Popup.rename_menu()
+              return
+            end
+
+            for i = 2, #fargs, 1 do
+              if
+                not vim.list_contains({ Util.strip_slash(fargs[i]), Util.strip_slash(fargs[i], ':p:~') }, fargs[i])
+              then
+                vim.notify('(:ProjectHistory rename): Invalid directory!', ERROR)
+                return
+              end
+              if not Popup.rename_input(fargs[i]) then
+                vim.notify(('(ProjectHistory): Unable to rename project `%s`!'):format(fargs[i]), ERROR)
+                return
+              end
+            end
+          end
+        end
+        if ctx.fargs[1] == 'import' then
+          if vim.tbl_isempty(fargs) then
+            Popup.gen_import_prompt()
             return
           end
 
-          History.migrate()
+          History.import_history_json(fargs[1], ctx.bang)
           return
         end
-
-        if #ctx.fargs == 1 then
-          Popup.rename_menu()
-          return
-        end
-
-        for i = 2, #ctx.fargs, 1 do
-          if
-            not vim.list_contains(
-              { Util.strip_slash(ctx.fargs[i]), Util.strip_slash(ctx.fargs[i], ':p:~') },
-              ctx.fargs[i]
-            )
-          then
-            vim.notify('(:ProjectHistory rename): Invalid directory!', ERROR)
+        if vim.g.project_log_loaded == 1 and ctx.fargs[1] == 'log' then
+          if vim.tbl_isempty(fargs) then
+            Log.toggle_win()
             return
-          elseif not Popup.rename_input(ctx.fargs[i]) then
-            vim.notify(('(ProjectHistory): Unable to rename project `%s`!'):format(ctx.fargs[i]), ERROR)
+          end
+
+          local arg = fargs[1] ---@type 'clear'|'close'|'open'|'toggle'
+          if arg == 'clear' then
+            Log.clear_log()
+            return
+          end
+          if arg == 'close' then
+            Log.close_win()
+            return
+          end
+          if arg == 'open' then
+            Log.open_win()
+            return
+          end
+          if arg == 'toggle' then
+            Log.toggle_win()
             return
           end
         end
-      end,
-    },
-    {
-      name = 'ProjectImport',
-      desc = 'Import project history from JSON file',
-      bang = true,
-      nargs = '?',
-      complete = 'file',
-      callback = function(ctx)
-        if vim.tbl_isempty(ctx.fargs) then
-          Popup.gen_import_prompt()
+        if vim.g.project_picker_loaded == 1 and ctx.fargs[1] == 'picker' and vim.tbl_isempty(fargs) then
+          local cmd = { 'rg', '--files', '--ignore', '--text', '--glob', '!.git/' }
+          if ctx.bang or Config.options.picker.hidden then
+            table.insert(cmd, '--hidden')
+          end
+          require('picker.sources.files').set({ cmd = cmd })
+          require('picker.windows').open(require('project.extensions.picker').source)
+
+          Log.debug('(:Project picker): Opening `picker.nvim` picker.')
+          return
+        end
+        if ctx.fargs[1] == 'recents' and vim.tbl_isempty(fargs) then
+          Popup.recents_menu()
+          return
+        end
+        if ctx.fargs[1] == 'root' and vim.tbl_isempty(fargs) then
+          local old_cwd = uv.cwd() or vim.fn.getcwd()
+          Core.on_buf_enter()
+
+          if (uv.cwd() or vim.fn.getcwd()) == old_cwd and not ctx.bang then
+            vim.notify('(:Project root): Current project is already in history!', WARN)
+            return
+          end
+          if ctx.bang then
+            vim.notify(uv.cwd() or vim.fn.getcwd(), INFO)
+          end
+          return
+        end
+        if ctx.fargs[1] == 'session' and vim.tbl_isempty(fargs) then
+          ctx.fargs = fargs
+          Popup.session_menu(ctx)
+          return
+        end
+        if vim.g.project_snacks_loaded == 1 and ctx.fargs[1] == 'snacks' and vim.tbl_isempty(fargs) then
+          require('project.extensions.snacks').pick()
+          return
+        end
+        if vim.g.project_telescope_loaded == 1 and ctx.fargs[1] == 'telescope' and vim.tbl_isempty(fargs) then
+          require('telescope._extensions.projects').projects()
           return
         end
 
-        History.import_history_json(ctx.fargs[1], ctx.bang)
-      end,
-    },
-    {
-      name = 'ProjectRecents',
-      desc = 'Opens a menu to select a project from your history',
-      callback = function()
-        Popup.recents_menu()
-      end,
-    },
-    {
-      name = 'ProjectRename',
-      bang = true,
-      nargs = '*',
-      desc = 'Deprecated command',
-      callback = function()
-        vim.notify(
-          [[
-This command has been deprecated, use `:ProjectHistory rename [...]` instead.
-        ]],
-          WARN
-        )
-      end,
-    },
-    {
-      name = 'ProjectRoot',
-      desc = 'Sets the current project root to the current cwd',
-      bang = true,
-      callback = function(ctx)
-        local old_cwd = uv.cwd() or vim.fn.getcwd()
-        Core.on_buf_enter()
-
-        local cwd = uv.cwd() or vim.fn.getcwd()
-        if cwd == old_cwd then
-          vim.notify('(ProjectRoot): Current project is already recorded!', WARN)
-          return
-        end
-
-        if ctx and ctx.bang then
-          vim.notify(uv.cwd() or vim.fn.getcwd(), INFO)
-        end
-      end,
-    },
-    {
-      name = 'ProjectSession',
-      desc = 'Opens a menu to switch between sessions',
-      bang = true,
-      callback = function(ctx)
-        Popup.session_menu(ctx)
+        vim.notify(('Usage:%s'):format(err_txt), WARN)
       end,
     },
   })

--- a/lua/project/config.lua
+++ b/lua/project/config.lua
@@ -51,8 +51,8 @@ function M.setup(options)
     Log.debug(('(%s.setup): `g:project_setup` set to `1`.'):format(MODSTR))
   end
 
-  Log.debug(('(%s.setup): User commands created.'):format(MODSTR))
   require('project.commands').create_user_commands()
+  Log.debug(('(%s.setup): User commands created.'):format(MODSTR))
 
   require('project.core').setup()
 

--- a/lua/project/extensions/fzf-lua.lua
+++ b/lua/project/extensions/fzf-lua.lua
@@ -68,13 +68,7 @@ function M.setup()
     return
   end
 
-  require('project.commands').new({
-    {
-      name = 'ProjectFzf',
-      desc = 'Run an fzf-lua prompt for project.nvim',
-      callback = M.run_fzf_lua,
-    },
-  })
+  vim.g.project_fzf_lua_loaded = 1
 end
 
 ---This runs assuming you have FZF-Lua installed!

--- a/lua/project/extensions/picker.lua
+++ b/lua/project/extensions/picker.lua
@@ -1,5 +1,4 @@
 local MODSTR = 'project.extensions.picker'
-local Commands = require('project.commands')
 local Log = require('project.util.log')
 local Util = require('project.util')
 
@@ -16,26 +15,6 @@ function M.setup()
   end
 
   vim.g.project_picker_loaded = 1
-
-  Commands.new({
-    {
-      name = 'ProjectPicker',
-      desc = 'Open the picker.nvim picker for project.nvim',
-      callback = function(ctx)
-        local cmd = { 'rg', '--files', '--ignore', '--text', '--glob', '!.git/' }
-        if ctx.bang or require('project.config').options.picker.hidden then
-          table.insert(cmd, '--hidden')
-        end
-        require('picker.sources.files').set({ cmd = cmd })
-        require('picker.windows').open(M.source)
-
-        Log.debug('(:ProectPicker): Opening `picker.nvim` picker.')
-      end,
-      bang = true,
-    },
-  })
-
-  Commands.create_user_commands()
 end
 
 return M

--- a/lua/project/extensions/snacks.lua
+++ b/lua/project/extensions/snacks.lua
@@ -138,18 +138,9 @@ function M.setup(opts)
     vim.notify('snacks.nvim is not installed! Aborting.', vim.log.levels.ERROR)
     return
   end
-
   Util.validate({ opts = { opts, { 'table', 'nil' }, true } })
 
   M.config = vim.tbl_deep_extend('force', M.config, opts or {})
-
-  require('project.commands').new({
-    {
-      name = 'ProjectSnacks',
-      desc = 'Project picker using snacks.nvim',
-      callback = M.pick,
-    },
-  })
 
   vim.g.project_snacks_loaded = 1
 end

--- a/lua/project/popup.lua
+++ b/lua/project/popup.lua
@@ -420,30 +420,36 @@ M.open_menu = M.new({
   choices = function()
     local res = { ---@type table<string, fun(ctx?: vim.api.keyset.create_user_command.command_args)>
       Session = M.session_menu,
-      New = vim.cmd.ProjectAdd,
+      New = function()
+        vim.cmd.Project('add')
+      end,
       Recents = M.recents_menu,
       Delete = M.delete_menu,
       Rename = M.rename_menu,
-      Config = require('project.commands').cmds.ProjectConfig,
-      Historyfile = vim.cmd.ProjectHistory,
+      Config = function()
+        vim.cmd.Project('config')
+      end,
+      Historyfile = function()
+        vim.cmd.Project('history')
+      end,
       Export = M.gen_export_prompt,
       Import = M.gen_import_prompt,
       Help = function()
         vim.cmd.help('project-nvim')
       end,
-      Checkhealth = vim.cmd.ProjectHealth or function()
-        vim.cmd.checkhealth('project')
+      Checkhealth = function()
+        vim.cmd.Project('health')
       end,
       Exit = function() end,
     }
-    if vim.g.project_picker_loaded == 1 and vim.cmd.ProjectPicker then
+    if vim.g.project_picker_loaded == 1 then
       res.Picker = function()
-        vim.cmd.ProjectPicker()
+        vim.cmd.Project('picker')
       end
     end
-    if vim.g.project_snacks_loaded == 1 and vim.cmd.ProjectSnacks then
+    if vim.g.project_snacks_loaded == 1 then
       res.Snacks = function()
-        vim.cmd.ProjectSnacks()
+        vim.cmd.Project('snacks')
       end
     end
     if vim.g.project_telescope_loaded == 1 then
@@ -453,8 +459,9 @@ M.open_menu = M.new({
       res.FzfLua = require('project.extensions.fzf-lua').run_fzf_lua
     end
     if Config.options.log.enabled then
-      local Log = require('project.util.log')
-      res.Log = not Log.window and Log.open_win or Log.close_win
+      res.Log = function()
+        vim.cmd.Project({ args = { 'log', 'toggle' } })
+      end
     end
     return res
   end,
@@ -477,10 +484,10 @@ M.open_menu = M.new({
       'Import',
       'Help',
     }
-    if vim.g.project_snacks_loaded == 1 and vim.cmd.ProjectSnacks then
+    if vim.g.project_snacks_loaded == 1 then
       table.insert(res_list, #res_list - 5, 'Snacks')
     end
-    if vim.g.project_picker_loaded == 1 and vim.cmd.ProjectPicker then
+    if vim.g.project_picker_loaded == 1 then
       table.insert(res_list, #res_list - 5, 'Picker')
     end
     if vim.g.project_telescope_loaded == 1 then

--- a/lua/project/util.lua
+++ b/lua/project/util.lua
@@ -1,7 +1,6 @@
 ---@module 'project._meta'
 
 local MODSTR = 'project.util'
-local ERROR = vim.log.levels.ERROR
 
 ---@class Project.Util
 local M = {}

--- a/lua/project/util/log.lua
+++ b/lua/project/util/log.lua
@@ -176,58 +176,6 @@ function M.write(data, lvl)
   return msg
 end
 
-function M.create_commands()
-  require('project.commands').new({
-    {
-      name = 'ProjectLog',
-      callback = function(ctx)
-        if vim.tbl_isempty(ctx.fargs) then
-          M.toggle_win()
-          return
-        end
-
-        local arg = ctx.fargs[1] ---@type 'clear'|'close'|'open'|'toggle'
-        if not vim.list_contains({ 'clear', 'close', 'open', 'toggle' }, arg) then
-          vim.notify('Usage - `:ProjectLog [clear|close|oppen|toggle]`', INFO)
-          return
-        end
-
-        if arg == 'clear' then
-          M.clear_log()
-          return
-        end
-        if arg == 'close' then
-          M.close_win()
-          return
-        end
-        if arg == 'open' then
-          M.open_win()
-          return
-        end
-
-        M.toggle_win()
-      end,
-      desc = 'Either opens the `project.nvim` log or clears the log file if `clear` is passed',
-      nargs = '?',
-      complete = function(_, line)
-        local args = vim.split(line, '%s+', { trimempty = false })
-        if (args[1]:sub(-1) == '!' and #args == 1) or #args > 2 then
-          return {}
-        end
-        local res = {}
-        for _, comp in ipairs({ 'clear', 'close', 'open', 'toggle' }) do
-          if vim.startswith(comp, args[2]) then
-            table.insert(res, comp)
-          end
-        end
-        table.sort(res)
-
-        return res
-      end,
-    },
-  })
-end
-
 ---@param mode uv.fs_open.flags
 ---@return integer|nil fd
 ---@return uv.fs_stat.result|nil stat
@@ -266,7 +214,8 @@ function M.setup()
   uv.fs_write(fd, (stat.size >= 1 and '\n' or '') .. os.date(('%s    %s    %s\n'):format(head, '%x  (%H:%M:%S)', head)))
 
   setup_watch()
-  M.create_commands()
+
+  vim.g.project_log_loaded = 1
 end
 
 function M.open_win()

--- a/lua/telescope/_extensions/projects.lua
+++ b/lua/telescope/_extensions/projects.lua
@@ -15,20 +15,12 @@ local projects = require('telescope._extensions.projects.main').projects
 ---@field projects fun(opts?: table)
 ---@field health function
 ---@field setup fun(opts?: table)
-local Projects = require('telescope').register_extension({
+local M = require('telescope').register_extension({
   setup = setup,
   health = require('telescope._extensions.projects.healthcheck'),
   exports = { projects = projects },
   projects = projects,
 })
 
-require('project.commands').new({
-  {
-    name = 'ProjectTelescope',
-    desc = 'Telescope shortcut for `projects` picker',
-    callback = Projects.projects,
-  },
-})
-
-return Projects
+return M
 -- vim: set ts=2 sts=2 sw=2 et ai si sta:


### PR DESCRIPTION
## Checks

- [X] I have read the `CONTRIBUTING.md` file
- [X] I have tested my changes (if applicable)

## Description

There are a lot of user commands. In this PR I decided to merge all user commands into a single one (`:Project`).

Instructions have been updated in the README, and later on I'll update the helpdoc.

<!-- vim: set ts=2 sts=2 sw=2 et ai si sta: -->
